### PR TITLE
Expose RestOperations through Twitter interface

### DIFF
--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/Twitter.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/Twitter.java
@@ -16,6 +16,7 @@
 package org.springframework.social.twitter.api;
 
 import org.springframework.social.ApiBinding;
+import org.springframework.web.client.RestOperations;
 
 
 /**
@@ -60,5 +61,11 @@ public interface Twitter extends ApiBinding {
 	 * Returns the portion of the Twitter API containing the user operations.
 	 */
 	UserOperations userOperations();
+
+	/**
+	 * Returns the underlying {@link RestOperations} object allowing for consumption of Twitter endpoints that may not be otherwise covered by the API binding.
+	 * The RestOperations object returned is configured to include an OAuth "Authorization" header on all requests.
+	 */
+	RestOperations restOperations();
 
 }

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/TwitterTemplate.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/TwitterTemplate.java
@@ -28,6 +28,7 @@ import org.springframework.social.twitter.api.SearchOperations;
 import org.springframework.social.twitter.api.TimelineOperations;
 import org.springframework.social.twitter.api.Twitter;
 import org.springframework.social.twitter.api.UserOperations;
+import org.springframework.web.client.RestOperations;
 import org.springframework.web.client.RestTemplate;
 
 /**
@@ -119,6 +120,10 @@ public class TwitterTemplate extends AbstractOAuth1ApiBinding implements Twitter
 	
 	public GeoOperations geoOperations() {
 		return geoOperations;
+	}
+	
+	public RestOperations restOperations() {
+		return getRestTemplate();
 	}
 
 	// AbstractOAuth1ApiBinding hooks


### PR DESCRIPTION
This enables clients to consume Twitter endpoints that may not yet be covered by the API binding.
