### PR TITLE
update tweet object to expose retweeted status, profile, and entities

### DIFF
--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/Entities.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/Entities.java
@@ -1,0 +1,152 @@
+package org.springframework.social.twitter.api;
+
+import org.codehaus.jackson.annotate.JsonIgnoreProperties;
+import org.codehaus.jackson.annotate.JsonProperty;
+
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * A json representation of entities found within twitter status objects.
+ * <p/>
+ * User: bowen
+ * Date: 12/26/11
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Entities implements Serializable
+{
+    private static final long serialVersionUID = 1L;
+
+    @JsonProperty("urls")
+    private List<UrlEntity> urls = new LinkedList<UrlEntity>();
+
+    @JsonProperty("hashtags")
+    private List<HashTagEntity> tags = new LinkedList<HashTagEntity>();
+
+    @JsonProperty("user_mentions")
+    private List<MentionEntity> mentions = new LinkedList<MentionEntity>();
+
+    @JsonProperty("media")
+    private List<MediaEntity> media = new LinkedList<MediaEntity>();
+
+
+    /**
+     * JSON constructor.
+     */
+    public Entities()
+    {
+
+    }
+
+
+    public List<UrlEntity> getUrls()
+    {
+        if (this.urls == null)
+        {
+            return Collections.emptyList();
+        }
+        return this.urls;
+    }
+
+
+    public List<HashTagEntity> getTags()
+    {
+        if (this.tags == null)
+        {
+            return Collections.emptyList();
+        }
+        return this.tags;
+    }
+
+
+    public List<MentionEntity> getMentions()
+    {
+        if (this.mentions == null)
+        {
+            return Collections.emptyList();
+        }
+        return this.mentions;
+    }
+
+
+    public List<MediaEntity> getMedia()
+    {
+        if (this.media == null)
+        {
+            return Collections.emptyList();
+        }
+        return this.media;
+    }
+
+
+    public boolean hasUrls()
+    {
+        return this.urls != null && !this.urls.isEmpty();
+    }
+
+
+    public boolean hasTags()
+    {
+        return this.tags != null && !this.tags.isEmpty();
+    }
+
+
+    public boolean hasMentions()
+    {
+        return this.mentions != null && !this.mentions.isEmpty();
+    }
+
+
+    public boolean hasMedia()
+    {
+        return this.media != null && !this.media.isEmpty();
+    }
+
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o)
+        {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass())
+        {
+            return false;
+        }
+
+        Entities entities = (Entities) o;
+
+        if (media != null ? !media.equals(entities.media) : entities.media != null)
+        {
+            return false;
+        }
+        if (mentions != null ? !mentions.equals(entities.mentions) : entities.mentions != null)
+        {
+            return false;
+        }
+        if (tags != null ? !tags.equals(entities.tags) : entities.tags != null)
+        {
+            return false;
+        }
+        if (urls != null ? !urls.equals(entities.urls) : entities.urls != null)
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+
+    @Override
+    public int hashCode()
+    {
+        int result = urls != null ? urls.hashCode() : 0;
+        result = 31 * result + (tags != null ? tags.hashCode() : 0);
+        result = 31 * result + (mentions != null ? mentions.hashCode() : 0);
+        result = 31 * result + (media != null ? media.hashCode() : 0);
+        return result;
+    }
+}

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/HashTagEntity.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/HashTagEntity.java
@@ -1,0 +1,84 @@
+package org.springframework.social.twitter.api;
+
+import org.codehaus.jackson.annotate.JsonProperty;
+
+import java.io.Serializable;
+import java.util.Arrays;
+
+/**
+ * A representation of tweet hashtags.
+ * <p/>
+ * User: bowen
+ * Date: 12/26/11
+ */
+public class HashTagEntity implements Serializable
+{
+    private static final long serialVersionUID = 1L;
+
+    @JsonProperty("text")
+    private String text;
+
+    @JsonProperty("indices")
+    private int[] indices;
+
+
+    /**
+     * JSON constructor.
+     */
+    public HashTagEntity()
+    {
+
+    }
+
+
+    public String getText()
+    {
+        return this.text;
+    }
+
+
+    public int[] getIndices()
+    {
+        if (this.indices == null || this.indices.length <= 0)
+        {
+            return new int[0];
+        }
+        return this.indices;
+    }
+
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o)
+        {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass())
+        {
+            return false;
+        }
+
+        HashTagEntity that = (HashTagEntity) o;
+
+        if (!Arrays.equals(indices, that.indices))
+        {
+            return false;
+        }
+        if (text != null ? !text.equals(that.text) : that.text != null)
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+
+    @Override
+    public int hashCode()
+    {
+        int result = text != null ? text.hashCode() : 0;
+        result = 31 * result + (indices != null ? Arrays.hashCode(indices) : 0);
+        return result;
+    }
+}

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/MediaEntity.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/MediaEntity.java
@@ -1,0 +1,170 @@
+package org.springframework.social.twitter.api;
+
+import org.codehaus.jackson.annotate.JsonIgnoreProperties;
+import org.codehaus.jackson.annotate.JsonProperty;
+
+import java.io.Serializable;
+import java.util.Arrays;
+
+/**
+ * A representation of embedded media entity.
+ * <p/>
+ * User: bowen
+ * Date: 12/26/11
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class MediaEntity implements Serializable
+{
+    private static final long serialVersionUID = 1L;
+
+    @JsonProperty("id")
+    private long id;
+
+    @JsonProperty("media_url")
+    private String mediaHttp;
+
+    @JsonProperty("media_url_https")
+    private String mediaHttps;
+
+    @JsonProperty("url")
+    private String url;
+
+    @JsonProperty("display_url")
+    private String display;
+
+    @JsonProperty("expanded_url")
+    private String expanded;
+
+    @JsonProperty("type")
+    private String type;
+
+    @JsonProperty("indices")
+    private int[] indices;
+
+
+    /**
+     * JSON constructor.
+     */
+    public MediaEntity()
+    {
+
+    }
+
+
+    public long getId()
+    {
+        return this.id;
+    }
+
+
+    public String getMediaUrl()
+    {
+        return this.mediaHttp;
+    }
+
+
+    public String getMediaSecureUrl()
+    {
+        return this.mediaHttps;
+    }
+
+
+    public String getType()
+    {
+        return this.type;
+    }
+
+
+    public String getDisplayUrl()
+    {
+        return display;
+    }
+
+
+    public String getExpandedUrl()
+    {
+        return this.expanded;
+    }
+
+
+    public String getUrl()
+    {
+        return this.url;
+    }
+
+
+    public int[] getIndices()
+    {
+        if (this.indices == null || this.indices.length <= 0)
+        {
+            return new int[0];
+        }
+        return this.indices;
+    }
+
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o)
+        {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass())
+        {
+            return false;
+        }
+
+        MediaEntity that = (MediaEntity) o;
+
+        if (id != that.id)
+        {
+            return false;
+        }
+        if (display != null ? !display.equals(that.display) : that.display != null)
+        {
+            return false;
+        }
+        if (expanded != null ? !expanded.equals(that.expanded) : that.expanded != null)
+        {
+            return false;
+        }
+        if (!Arrays.equals(indices, that.indices))
+        {
+            return false;
+        }
+        if (mediaHttp != null ? !mediaHttp.equals(that.mediaHttp) : that.mediaHttp != null)
+        {
+            return false;
+        }
+        if (mediaHttps != null ? !mediaHttps.equals(that.mediaHttps) : that.mediaHttps != null)
+        {
+            return false;
+        }
+        if (type != null ? !type.equals(that.type) : that.type != null)
+        {
+            return false;
+        }
+        if (url != null ? !url.equals(that.url) : that.url != null)
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+
+    @Override
+    public int hashCode()
+    {
+        int result = (int) (id ^ (id >>> 32));
+        result = 31 * result + (mediaHttp != null ? mediaHttp.hashCode() : 0);
+        result = 31 * result + (mediaHttps != null ? mediaHttps.hashCode() : 0);
+        result = 31 * result + (url != null ? url.hashCode() : 0);
+        result = 31 * result + (display != null ? display.hashCode() : 0);
+        result = 31 * result + (expanded != null ? expanded.hashCode() : 0);
+        result = 31 * result + (type != null ? type.hashCode() : 0);
+        result = 31 * result + (indices != null ? Arrays.hashCode(indices) : 0);
+        return result;
+    }
+}

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/MentionEntity.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/MentionEntity.java
@@ -1,0 +1,114 @@
+package org.springframework.social.twitter.api;
+
+import org.codehaus.jackson.annotate.JsonIgnoreProperties;
+import org.codehaus.jackson.annotate.JsonProperty;
+
+import java.io.Serializable;
+import java.util.Arrays;
+
+/**
+ * A user mention entity.
+ * <p/>
+ * User: bowen
+ * Date: 12/26/11
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class MentionEntity implements Serializable
+{
+    private static final long serialVersionUID = 1L;
+
+    @JsonProperty("id")
+    private long id;
+
+    @JsonProperty("screen_name")
+    private String screenName;
+
+    @JsonProperty("name")
+    private String name;
+
+    @JsonProperty("indices")
+    private int[] indices;
+
+
+    /**
+     * JSON constructor.
+     */
+    public MentionEntity()
+    {
+
+    }
+
+
+    public long getId()
+    {
+        return this.id;
+    }
+
+
+    public String getName()
+    {
+        return this.name;
+    }
+
+
+    public String getScreenName()
+    {
+        return this.screenName;
+    }
+
+
+    public int[] getIndices()
+    {
+        if (this.indices == null || this.indices.length <= 0)
+        {
+            return new int[0];
+        }
+        return this.indices;
+    }
+
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o)
+        {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass())
+        {
+            return false;
+        }
+
+        MentionEntity that = (MentionEntity) o;
+
+        if (id != that.id)
+        {
+            return false;
+        }
+        if (name != null ? !name.equals(that.name) : that.name != null)
+        {
+            return false;
+        }
+        if (!Arrays.equals(indices, that.indices))
+        {
+            return false;
+        }
+        if (screenName != null ? !screenName.equals(that.screenName) : that.screenName != null)
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+
+    @Override
+    public int hashCode()
+    {
+        int result = (int) (id ^ (id >>> 32));
+        result = 31 * result + (screenName != null ? screenName.hashCode() : 0);
+        result = 31 * result + (name != null ? name.hashCode() : 0);
+        result = 31 * result + (indices != null ? Arrays.hashCode(indices) : 0);
+        return result;
+    }
+}

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/TimelineOperations.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/TimelineOperations.java
@@ -15,14 +15,14 @@
  */
 package org.springframework.social.twitter.api;
 
-import java.util.List;
-
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.io.Resource;
 import org.springframework.social.ApiException;
 import org.springframework.social.MissingAuthorizationException;
 import org.springframework.social.OperationNotPermittedException;
+
+import java.util.List;
 
 
 /**
@@ -521,6 +521,7 @@ public interface TimelineOperations {
 	 * @throws MissingAuthorizationException if TwitterTemplate was not created with OAuth credentials.
 	 */
 	List<Long> getRetweetedByIds(long tweetId, int page, int pageSize);
+
 
 	/**
 	 * Retrieves the 20 most recent tweets favorited by the authenticated user.

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/Tweet.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/Tweet.java
@@ -15,127 +15,300 @@
  */
 package org.springframework.social.twitter.api;
 
+import java.io.Serializable;
 import java.util.Date;
 
 /**
  * Represents a Twitter status update (e.g., a "tweet").
+ *
  * @author Craig Walls
  */
-public class Tweet {
-	private long id;
-	private String text;
-	private Date createdAt;
-	private String fromUser;
-	private String profileImageUrl;
-	private Long toUserId;
-	private Long inReplyToStatusId;
-	private long fromUserId;
-	private String languageCode;
-	private String source;
-	private Integer retweetCount;
-	
-	public Tweet(long id, String text, Date createdAt, String fromUser, String profileImageUrl, Long toUserId, long fromUserId, String languageCode, String source) {
-		this.id = id;
-		this.text = text;
-		this.createdAt = createdAt;
-		this.fromUser = fromUser;
-		this.profileImageUrl = profileImageUrl;
-		this.toUserId = toUserId;
-		this.fromUserId = fromUserId;
-		this.languageCode = languageCode;
-		this.source = source;		
-	}
+public class Tweet implements Serializable
+{
+    private static final long serialVersionUID = 1L;
 
-	public String getText() {
-		return text;
-	}
+    private final long id;
 
-	public void setText(String text) {
-		this.text = text;
-	}
+    private final String text;
 
-	public Date getCreatedAt() {
-		return createdAt;
-	}
+    private final Date createdAt;
 
-	public void setCreatedAt(Date createdAt) {
-		this.createdAt = createdAt;
-	}
+    private final String fromUser;
 
-	public String getFromUser() {
-		return fromUser;
-	}
+    private final String profileImageUrl;
 
-	public void setFromUser(String fromUser) {
-		this.fromUser = fromUser;
-	}
+    private final Long inReplyToStatusId;
 
-	public long getId() {
-		return id;
-	}
+    private final Long inReplyToUserId;
 
-	public void setId(long id) {
-		this.id = id;
-	}
+    private final String inReplyToScreenName;
 
-	public String getProfileImageUrl() {
-		return profileImageUrl;
-	}
+    private final long fromUserId;
 
-	public void setProfileImageUrl(String profileImageUrl) {
-		this.profileImageUrl = profileImageUrl;
-	}
+    private final String languageCode;
 
-	public Long getToUserId() {
-		return toUserId;
-	}
+    private final String source;
 
-	public void setToUserId(Long toUserId) {
-		this.toUserId = toUserId;
-	}
+    private final Tweet retweetedStatus;
 
-	public long getFromUserId() {
-		return fromUserId;
-	}
-	
-	public void setInReplyToStatusId(Long inReplyToStatusId) {
-		this.inReplyToStatusId = inReplyToStatusId;
-	}
-	
-	public Long getInReplyToStatusId() {
-		return inReplyToStatusId;
-	}
+    private final Integer retweetCount;
 
-	public void setFromUserId(long fromUserId) {
-		this.fromUserId = fromUserId;
-	}
+    private final boolean retweetedByMe;
 
-	public String getLanguageCode() {
-		return languageCode;
-	}
+    private final boolean truncated;
 
-	public void setLanguageCode(String languageCode) {
-		this.languageCode = languageCode;
-	}
+    private final boolean favorited;
 
-	public String getSource() {
-		return source;
-	}
+    private final Entities entities;
 
-	public void setSource(String source) {
-		this.source = source;
-	}
+    private final TwitterProfile user;
 
-	public void setRetweetCount(Integer retweetCount) {
-		this.retweetCount = retweetCount;		
-	}
-	
-	/**
-	 * The number of times this tweet has been retweeted.
-	 * Only available in timeline results. 
-	 * getRetweetCount() will return null for Tweet objects returned in search results.
-	 */
-	public Integer getRetweetCount() {
-		return retweetCount;
-	}
+
+    public Tweet(long id, String text, Date createdAt, long fromUserId, String fromUser, String profileImageUrl, String languageCode, Long toUserId, String toUserName, Long inReplyToStatusId, String source, Integer retweetCount, Tweet retweetedTweet, boolean retweetedByMe, boolean truncated, boolean favorited, Entities entities, Tweet retweetedStatus, TwitterProfile user)
+    {
+        this.id = id;
+        this.text = text;
+        this.createdAt = createdAt;
+        this.fromUser = fromUser;
+        this.profileImageUrl = profileImageUrl;
+        this.inReplyToUserId = toUserId;
+        this.inReplyToScreenName = toUserName;
+        this.inReplyToStatusId = inReplyToStatusId;
+        this.fromUserId = fromUserId;
+        this.languageCode = languageCode;
+        this.source = source;
+        this.retweetCount = retweetCount;
+        this.retweetedByMe = retweetedByMe;
+        this.retweetedStatus = retweetedStatus;
+        this.truncated = truncated;
+        this.favorited = favorited;
+        this.entities = entities;
+        this.user = user;
+    }
+
+
+    public String getText()
+    {
+        return text;
+    }
+
+
+    public TwitterProfile getUser()
+    {
+        return this.user;
+    }
+
+
+    public Date getCreatedAt()
+    {
+        return createdAt;
+    }
+
+
+    public String getFromUser()
+    {
+        return fromUser;
+    }
+
+
+    public long getId()
+    {
+        return id;
+    }
+
+
+    public String getProfileImageUrl()
+    {
+        return profileImageUrl;
+    }
+
+
+    public Long getToUserId()
+    {
+        return this.inReplyToUserId;
+    }
+
+
+    public boolean hasMentions()
+    {
+        if (this.entities == null)
+        {
+            return false;
+        }
+        return !this.entities.getMentions().isEmpty();
+    }
+
+
+    public boolean isRetweet()
+    {
+        return this.retweetedStatus != null;
+    }
+
+
+    public Tweet getRetweetedStatus()
+    {
+        return this.retweetedStatus;
+    }
+
+
+    public long getFromUserId()
+    {
+        return fromUserId;
+    }
+
+
+    public String getInReplyToScreenName()
+    {
+        return this.inReplyToScreenName;
+    }
+
+
+    public Long getInReplyToUserId()
+    {
+        return this.inReplyToUserId;
+    }
+
+
+    public Long getInReplyToStatusId()
+    {
+        return inReplyToStatusId;
+    }
+
+
+    public String getLanguageCode()
+    {
+        return languageCode;
+    }
+
+
+    public String getSource()
+    {
+        return source;
+    }
+
+
+    /**
+     * The number of times this tweet has been retweeted.
+     * Only available in timeline results.
+     * getRetweetCount() will return null for Tweet objects returned in search results.
+     */
+    public Integer getRetweetCount() {
+        return retweetCount;
+    }
+
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o)
+        {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass())
+        {
+            return false;
+        }
+
+        Tweet tweet = (Tweet) o;
+
+        if (favorited != tweet.favorited)
+        {
+            return false;
+        }
+        if (fromUserId != tweet.fromUserId)
+        {
+            return false;
+        }
+        if (id != tweet.id)
+        {
+            return false;
+        }
+        if (retweetCount != tweet.retweetCount)
+        {
+            return false;
+        }
+        if (retweetedByMe != tweet.retweetedByMe)
+        {
+            return false;
+        }
+        if (truncated != tweet.truncated)
+        {
+            return false;
+        }
+        if (createdAt != null ? !createdAt.equals(tweet.createdAt) : tweet.createdAt != null)
+        {
+            return false;
+        }
+        if (entities != null ? !entities.equals(tweet.entities) : tweet.entities != null)
+        {
+            return false;
+        }
+        if (fromUser != null ? !fromUser.equals(tweet.fromUser) : tweet.fromUser != null)
+        {
+            return false;
+        }
+        if (inReplyToScreenName != null ? !inReplyToScreenName.equals(tweet.inReplyToScreenName) : tweet.inReplyToScreenName != null)
+        {
+            return false;
+        }
+        if (inReplyToStatusId != null ? !inReplyToStatusId.equals(tweet.inReplyToStatusId) : tweet.inReplyToStatusId != null)
+        {
+            return false;
+        }
+        if (inReplyToUserId != null ? !inReplyToUserId.equals(tweet.inReplyToUserId) : tweet.inReplyToUserId != null)
+        {
+            return false;
+        }
+        if (languageCode != null ? !languageCode.equals(tweet.languageCode) : tweet.languageCode != null)
+        {
+            return false;
+        }
+        if (profileImageUrl != null ? !profileImageUrl.equals(tweet.profileImageUrl) : tweet.profileImageUrl != null)
+        {
+            return false;
+        }
+        if (retweetedStatus != null ? !retweetedStatus.equals(tweet.retweetedStatus) : tweet.retweetedStatus != null)
+        {
+            return false;
+        }
+        if (source != null ? !source.equals(tweet.source) : tweet.source != null)
+        {
+            return false;
+        }
+        if (text != null ? !text.equals(tweet.text) : tweet.text != null)
+        {
+            return false;
+        }
+        if (user != null ? !user.equals(tweet.user) : tweet.user != null)
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+
+    @Override
+    public int hashCode()
+    {
+        int result = (int) (id ^ (id >>> 32));
+        result = 31 * result + (text != null ? text.hashCode() : 0);
+        result = 31 * result + (createdAt != null ? createdAt.hashCode() : 0);
+        result = 31 * result + (fromUser != null ? fromUser.hashCode() : 0);
+        result = 31 * result + (profileImageUrl != null ? profileImageUrl.hashCode() : 0);
+        result = 31 * result + (inReplyToStatusId != null ? inReplyToStatusId.hashCode() : 0);
+        result = 31 * result + (inReplyToUserId != null ? inReplyToUserId.hashCode() : 0);
+        result = 31 * result + (inReplyToScreenName != null ? inReplyToScreenName.hashCode() : 0);
+        result = 31 * result + (int) (fromUserId ^ (fromUserId >>> 32));
+        result = 31 * result + (languageCode != null ? languageCode.hashCode() : 0);
+        result = 31 * result + (source != null ? source.hashCode() : 0);
+        result = 31 * result + (retweetedStatus != null ? retweetedStatus.hashCode() : 0);
+        result = 31 * result + retweetCount;
+        result = 31 * result + (retweetedByMe ? 1 : 0);
+        result = 31 * result + (truncated ? 1 : 0);
+        result = 31 * result + (favorited ? 1 : 0);
+        result = 31 * result + (entities != null ? entities.hashCode() : 0);
+        result = 31 * result + (user != null ? user.hashCode() : 0);
+        return result;
+    }
 }

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/TwitterProfile.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/TwitterProfile.java
@@ -60,11 +60,8 @@ public class TwitterProfile implements Serializable {
 	private String linkColor;
 	private boolean showAllInlineMedia;
 	
-	public static long getSerialversionuid() {
-		return serialVersionUID;
-	}
 
-	public TwitterProfile(long id, String screenName, String name, String url, String profileImageUrl, String description, String location, Date createdDate) {
+    public TwitterProfile(long id, String screenName, String name, String url, String profileImageUrl, String description, String location, Date createdDate) {
 		this.id = id;
 		this.screenName = screenName;
 		this.name = name;
@@ -336,4 +333,195 @@ public class TwitterProfile implements Serializable {
 	public boolean showAllInlineMedia() {
 		return showAllInlineMedia;
 	}
+
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o)
+        {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass())
+        {
+            return false;
+        }
+
+        TwitterProfile that = (TwitterProfile) o;
+
+        if (backgroundImageTiled != that.backgroundImageTiled)
+        {
+            return false;
+        }
+        if (contributorsEnabled != that.contributorsEnabled)
+        {
+            return false;
+        }
+        if (favoritesCount != that.favoritesCount)
+        {
+            return false;
+        }
+        if (followRequestSent != that.followRequestSent)
+        {
+            return false;
+        }
+        if (followersCount != that.followersCount)
+        {
+            return false;
+        }
+        if (following != that.following)
+        {
+            return false;
+        }
+        if (friendsCount != that.friendsCount)
+        {
+            return false;
+        }
+        if (geoEnabled != that.geoEnabled)
+        {
+            return false;
+        }
+        if (id != that.id)
+        {
+            return false;
+        }
+        if (isProtected != that.isProtected)
+        {
+            return false;
+        }
+        if (listedCount != that.listedCount)
+        {
+            return false;
+        }
+        if (notificationsEnabled != that.notificationsEnabled)
+        {
+            return false;
+        }
+        if (showAllInlineMedia != that.showAllInlineMedia)
+        {
+            return false;
+        }
+        if (statusesCount != that.statusesCount)
+        {
+            return false;
+        }
+        if (translator != that.translator)
+        {
+            return false;
+        }
+        if (useBackgroundImage != that.useBackgroundImage)
+        {
+            return false;
+        }
+        if (utcOffset != that.utcOffset)
+        {
+            return false;
+        }
+        if (verified != that.verified)
+        {
+            return false;
+        }
+        if (backgroundColor != null ? !backgroundColor.equals(that.backgroundColor) : that.backgroundColor != null)
+        {
+            return false;
+        }
+        if (backgroundImageUrl != null ? !backgroundImageUrl.equals(that.backgroundImageUrl) : that.backgroundImageUrl != null)
+        {
+            return false;
+        }
+        if (createdDate != null ? !createdDate.equals(that.createdDate) : that.createdDate != null)
+        {
+            return false;
+        }
+        if (description != null ? !description.equals(that.description) : that.description != null)
+        {
+            return false;
+        }
+        if (language != null ? !language.equals(that.language) : that.language != null)
+        {
+            return false;
+        }
+        if (linkColor != null ? !linkColor.equals(that.linkColor) : that.linkColor != null)
+        {
+            return false;
+        }
+        if (location != null ? !location.equals(that.location) : that.location != null)
+        {
+            return false;
+        }
+        if (name != null ? !name.equals(that.name) : that.name != null)
+        {
+            return false;
+        }
+        if (profileImageUrl != null ? !profileImageUrl.equals(that.profileImageUrl) : that.profileImageUrl != null)
+        {
+            return false;
+        }
+        if (screenName != null ? !screenName.equals(that.screenName) : that.screenName != null)
+        {
+            return false;
+        }
+        if (sidebarBorderColor != null ? !sidebarBorderColor.equals(that.sidebarBorderColor) : that.sidebarBorderColor != null)
+        {
+            return false;
+        }
+        if (sidebarFillColor != null ? !sidebarFillColor.equals(that.sidebarFillColor) : that.sidebarFillColor != null)
+        {
+            return false;
+        }
+        if (textColor != null ? !textColor.equals(that.textColor) : that.textColor != null)
+        {
+            return false;
+        }
+        if (timeZone != null ? !timeZone.equals(that.timeZone) : that.timeZone != null)
+        {
+            return false;
+        }
+        if (url != null ? !url.equals(that.url) : that.url != null)
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+
+    @Override
+    public int hashCode()
+    {
+        int result = (int) (id ^ (id >>> 32));
+        result = 31 * result + (screenName != null ? screenName.hashCode() : 0);
+        result = 31 * result + (name != null ? name.hashCode() : 0);
+        result = 31 * result + (url != null ? url.hashCode() : 0);
+        result = 31 * result + (profileImageUrl != null ? profileImageUrl.hashCode() : 0);
+        result = 31 * result + (description != null ? description.hashCode() : 0);
+        result = 31 * result + (location != null ? location.hashCode() : 0);
+        result = 31 * result + (createdDate != null ? createdDate.hashCode() : 0);
+        result = 31 * result + (language != null ? language.hashCode() : 0);
+        result = 31 * result + statusesCount;
+        result = 31 * result + friendsCount;
+        result = 31 * result + followersCount;
+        result = 31 * result + favoritesCount;
+        result = 31 * result + listedCount;
+        result = 31 * result + (following ? 1 : 0);
+        result = 31 * result + (followRequestSent ? 1 : 0);
+        result = 31 * result + (isProtected ? 1 : 0);
+        result = 31 * result + (notificationsEnabled ? 1 : 0);
+        result = 31 * result + (verified ? 1 : 0);
+        result = 31 * result + (geoEnabled ? 1 : 0);
+        result = 31 * result + (contributorsEnabled ? 1 : 0);
+        result = 31 * result + (translator ? 1 : 0);
+        result = 31 * result + (timeZone != null ? timeZone.hashCode() : 0);
+        result = 31 * result + utcOffset;
+        result = 31 * result + (sidebarBorderColor != null ? sidebarBorderColor.hashCode() : 0);
+        result = 31 * result + (sidebarFillColor != null ? sidebarFillColor.hashCode() : 0);
+        result = 31 * result + (backgroundColor != null ? backgroundColor.hashCode() : 0);
+        result = 31 * result + (useBackgroundImage ? 1 : 0);
+        result = 31 * result + (backgroundImageUrl != null ? backgroundImageUrl.hashCode() : 0);
+        result = 31 * result + (backgroundImageTiled ? 1 : 0);
+        result = 31 * result + (textColor != null ? textColor.hashCode() : 0);
+        result = 31 * result + (linkColor != null ? linkColor.hashCode() : 0);
+        result = 31 * result + (showAllInlineMedia ? 1 : 0);
+        return result;
+    }
 }

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/UrlEntity.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/UrlEntity.java
@@ -1,0 +1,112 @@
+package org.springframework.social.twitter.api;
+
+import org.codehaus.jackson.annotate.JsonProperty;
+
+import java.io.Serializable;
+import java.util.Arrays;
+
+/**
+ * A representation of a URL found within a tweet entity.
+ * <p/>
+ * User: bowen
+ * Date: 12/26/11
+ */
+public class UrlEntity implements Serializable
+{
+    private static final long serialVersionUID = 1L;
+
+    @JsonProperty("display_url")
+    private String display;
+
+    @JsonProperty("expanded_url")
+    private String expanded;
+
+    @JsonProperty("url")
+    private String url;
+
+    @JsonProperty("indices")
+    private int[] indices;
+
+
+    /**
+     * JSON constructor.
+     */
+    public UrlEntity()
+    {
+
+    }
+
+
+    public String getDisplayUrl()
+    {
+        return this.display;
+    }
+
+
+    public String getExpandedUrl()
+    {
+        return this.expanded;
+    }
+
+
+    public String getUrl()
+    {
+        return this.url;
+    }
+
+
+    public int[] getIndices()
+    {
+        if (this.indices == null || this.indices.length <= 0)
+        {
+            return new int[0];
+        }
+        return this.indices;
+    }
+
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o)
+        {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass())
+        {
+            return false;
+        }
+
+        UrlEntity urlEntity = (UrlEntity) o;
+
+        if (display != null ? !display.equals(urlEntity.display) : urlEntity.display != null)
+        {
+            return false;
+        }
+        if (expanded != null ? !expanded.equals(urlEntity.expanded) : urlEntity.expanded != null)
+        {
+            return false;
+        }
+        if (!Arrays.equals(indices, urlEntity.indices))
+        {
+            return false;
+        }
+        if (url != null ? !url.equals(urlEntity.url) : urlEntity.url != null)
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+
+    @Override
+    public int hashCode()
+    {
+        int result = display != null ? display.hashCode() : 0;
+        result = 31 * result + (expanded != null ? expanded.hashCode() : 0);
+        result = 31 * result + (url != null ? url.hashCode() : 0);
+        result = 31 * result + (indices != null ? Arrays.hashCode(indices) : 0);
+        return result;
+    }
+}

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/SearchTemplate.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/SearchTemplate.java
@@ -15,10 +15,6 @@
  */
 package org.springframework.social.twitter.api.impl;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 import org.springframework.social.twitter.api.SavedSearch;
 import org.springframework.social.twitter.api.SearchOperations;
 import org.springframework.social.twitter.api.SearchResults;
@@ -27,6 +23,10 @@ import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
 
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 /**
  * Implementation of {@link SearchOperations}, providing a binding to Twitter's search and trend-oriented REST resources.
  * @author Craig Walls
@@ -34,10 +34,14 @@ import org.springframework.web.client.RestTemplate;
 class SearchTemplate extends AbstractTwitterOperations implements SearchOperations {
 
 	private final RestTemplate restTemplate;
+
+    private final boolean includeEntities;
+
 		
-	public SearchTemplate(RestTemplate restTemplate, boolean isAuthorizedForUser) {
+	public SearchTemplate(final RestTemplate restTemplate, final boolean isAuthorizedForUser, final boolean includeEntities) {
 		super(isAuthorizedForUser);
 		this.restTemplate = restTemplate;
+        this.includeEntities = includeEntities;
 	}
 
 	public SearchResults search(String query) {
@@ -62,6 +66,10 @@ class SearchTemplate extends AbstractTwitterOperations implements SearchOperatio
 			searchUrl += "&max_id={max}";
 			parameters.put("max", String.valueOf(maxId));
 		}
+        if (this.includeEntities)
+        {
+            parameters.put("include_entities", "true");
+        }
 		return restTemplate.getForObject(searchUrl, SearchResults.class, parameters);
 	}
 

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/TimelineTemplate.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/TimelineTemplate.java
@@ -15,9 +15,6 @@
  */
 package org.springframework.social.twitter.api.impl;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import org.springframework.core.io.Resource;
 import org.springframework.social.twitter.api.StatusDetails;
 import org.springframework.social.twitter.api.TimelineOperations;
@@ -27,6 +24,9 @@ import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * Implementation of {@link TimelineOperations}, providing a binding to Twitter's tweet and timeline-oriented REST resources.
  * @author Craig Walls
@@ -35,13 +35,18 @@ class TimelineTemplate extends AbstractTwitterOperations implements TimelineOper
 	
 	private final RestTemplate restTemplate;
 
-	public TimelineTemplate(RestTemplate restTemplate, boolean isAuthorizedForUser) {
+    private final boolean includeEntities;
+
+
+	public TimelineTemplate(final RestTemplate restTemplate, final boolean isAuthorizedForUser, final boolean includeEntities) {
 		super(isAuthorizedForUser);
 		this.restTemplate = restTemplate;
+        this.includeEntities = includeEntities;
 	}
 
 	public List<Tweet> getPublicTimeline() {
-		return restTemplate.getForObject(buildUri("statuses/public_timeline.json"), TweetList.class);
+        MultiValueMap<String, String> parameters = this.buildParameters();
+		return restTemplate.getForObject(buildUri("statuses/public_timeline.json", parameters), TweetList.class);
 	}
 
 	public List<Tweet> getHomeTimeline() {
@@ -55,6 +60,7 @@ class TimelineTemplate extends AbstractTwitterOperations implements TimelineOper
 	public List<Tweet> getHomeTimeline(int page, int pageSize, long sinceId, long maxId) {
 		requireAuthorization();
 		MultiValueMap<String, String> parameters = PagingUtils.buildPagingParametersWithCount(page, pageSize, sinceId, maxId);
+        parameters.putAll(this.buildParameters());
 		return restTemplate.getForObject(buildUri("statuses/home_timeline.json", parameters), TweetList.class);
 	}
 	
@@ -69,6 +75,7 @@ class TimelineTemplate extends AbstractTwitterOperations implements TimelineOper
 	public List<Tweet> getUserTimeline(int page, int pageSize, long sinceId, long maxId) {
 		requireAuthorization();
 		MultiValueMap<String, String> parameters = PagingUtils.buildPagingParametersWithCount(page, pageSize, sinceId, maxId);
+        parameters.putAll(this.buildParameters());
 		return restTemplate.getForObject(buildUri("statuses/user_timeline.json", parameters), TweetList.class);
 	}
 
@@ -83,6 +90,7 @@ class TimelineTemplate extends AbstractTwitterOperations implements TimelineOper
 	public List<Tweet> getUserTimeline(String screenName, int page, int pageSize, long sinceId, long maxId) {
 		MultiValueMap<String, String> parameters = PagingUtils.buildPagingParametersWithCount(page, pageSize, sinceId, maxId);
 		parameters.set("screen_name", screenName);
+        parameters.putAll(this.buildParameters());
 		return restTemplate.getForObject(buildUri("statuses/user_timeline.json", parameters), TweetList.class);
 	}
 
@@ -97,6 +105,7 @@ class TimelineTemplate extends AbstractTwitterOperations implements TimelineOper
 	public List<Tweet> getUserTimeline(long userId, int page, int pageSize, long sinceId, long maxId) {
 		MultiValueMap<String, String> parameters = PagingUtils.buildPagingParametersWithCount(page, pageSize, sinceId, maxId);
 		parameters.set("user_id", String.valueOf(userId));
+        parameters.putAll(this.buildParameters());
 		return restTemplate.getForObject(buildUri("statuses/user_timeline.json", parameters), TweetList.class);
 	}
 
@@ -111,6 +120,7 @@ class TimelineTemplate extends AbstractTwitterOperations implements TimelineOper
 	public List<Tweet> getMentions(int page, int pageSize, long sinceId, long maxId) {
 		requireAuthorization();
 		MultiValueMap<String, String> parameters = PagingUtils.buildPagingParametersWithCount(page, pageSize, sinceId, maxId);
+        parameters.putAll(this.buildParameters());
 		return restTemplate.getForObject(buildUri("statuses/mentions.json", parameters), TweetList.class);
 	}
 
@@ -125,6 +135,7 @@ class TimelineTemplate extends AbstractTwitterOperations implements TimelineOper
 	public List<Tweet> getRetweetedByMe(int page, int pageSize, long sinceId, long maxId) {
 		requireAuthorization();
 		MultiValueMap<String, String> parameters = PagingUtils.buildPagingParametersWithCount(page, pageSize, sinceId, maxId);
+        parameters.putAll(this.buildParameters());
 		return restTemplate.getForObject(buildUri("statuses/retweeted_by_me.json", parameters), TweetList.class);
 	}
 
@@ -140,6 +151,7 @@ class TimelineTemplate extends AbstractTwitterOperations implements TimelineOper
 		requireAuthorization();
 		MultiValueMap<String, String> parameters = PagingUtils.buildPagingParametersWithCount(page, pageSize, sinceId, maxId);
 		parameters.set("user_id", String.valueOf(userId));
+        parameters.putAll(this.buildParameters());
 		return restTemplate.getForObject(buildUri("statuses/retweeted_by_user.json", parameters), TweetList.class);
 	}
 
@@ -155,6 +167,7 @@ class TimelineTemplate extends AbstractTwitterOperations implements TimelineOper
 		requireAuthorization();
 		MultiValueMap<String, String> parameters = PagingUtils.buildPagingParametersWithCount(page, pageSize, sinceId, maxId);
 		parameters.set("screen_name", screenName);
+        parameters.putAll(this.buildParameters());
 		return restTemplate.getForObject(buildUri("statuses/retweeted_by_user.json", parameters), TweetList.class);
 	}
 
@@ -169,6 +182,7 @@ class TimelineTemplate extends AbstractTwitterOperations implements TimelineOper
 	public List<Tweet> getRetweetedToMe(int page, int pageSize, long sinceId, long maxId) {
 		requireAuthorization();
 		MultiValueMap<String, String> parameters = PagingUtils.buildPagingParametersWithCount(page, pageSize, sinceId, maxId);
+        parameters.putAll(this.buildParameters());
 		return restTemplate.getForObject(buildUri("statuses/retweeted_to_me.json", parameters), TweetList.class);
 	}
 
@@ -184,6 +198,7 @@ class TimelineTemplate extends AbstractTwitterOperations implements TimelineOper
 		requireAuthorization();
 		MultiValueMap<String, String> parameters = PagingUtils.buildPagingParametersWithCount(page, pageSize, sinceId, maxId);
 		parameters.set("user_id", String.valueOf(userId));
+        parameters.putAll(this.buildParameters());
 		return restTemplate.getForObject(buildUri("statuses/retweeted_to_user.json", parameters), TweetList.class);
 	}
 
@@ -199,6 +214,7 @@ class TimelineTemplate extends AbstractTwitterOperations implements TimelineOper
 		requireAuthorization();
 		MultiValueMap<String, String> parameters = PagingUtils.buildPagingParametersWithCount(page, pageSize, sinceId, maxId);
 		parameters.set("screen_name", screenName);
+        parameters.putAll(this.buildParameters());
 		return restTemplate.getForObject(buildUri("statuses/retweeted_to_user.json", parameters), TweetList.class);
 	}
 
@@ -213,11 +229,13 @@ class TimelineTemplate extends AbstractTwitterOperations implements TimelineOper
 	public List<Tweet> getRetweetsOfMe(int page, int pageSize, long sinceId, long maxId) {
 		requireAuthorization();
 		MultiValueMap<String, String> parameters = PagingUtils.buildPagingParametersWithCount(page, pageSize, sinceId, maxId);
+        parameters.putAll(this.buildParameters());
 		return restTemplate.getForObject(buildUri("statuses/retweets_of_me.json", parameters), TweetList.class);
 	}
 
 	public Tweet getStatus(long tweetId) {
-		return restTemplate.getForObject(buildUri("statuses/show/" + tweetId + ".json"), Tweet.class);
+        MultiValueMap<String, String> parameters = this.buildParameters();
+		return restTemplate.getForObject(buildUri("statuses/show/" + tweetId + ".json", parameters), Tweet.class);
 	}
 
 	public Tweet updateStatus(String message) {
@@ -233,6 +251,10 @@ class TimelineTemplate extends AbstractTwitterOperations implements TimelineOper
 		MultiValueMap<String, Object> tweetParams = new LinkedMultiValueMap<String, Object>();
 		tweetParams.add("status", message);
 		tweetParams.putAll(details.toParameterMap());
+        if (this.includeEntities)
+        {
+            tweetParams.set("include_entities", "true");
+        }
 		return restTemplate.postForObject(buildUri("statuses/update.json"), tweetParams, Tweet.class);
 	}
 
@@ -242,6 +264,10 @@ class TimelineTemplate extends AbstractTwitterOperations implements TimelineOper
 		tweetParams.add("status", message);
 		tweetParams.add("media", media);
 		tweetParams.putAll(details.toParameterMap());
+        if (this.includeEntities)
+        {
+            tweetParams.set("include_entities", "true");
+        }
 		return restTemplate.postForObject("https://upload.twitter.com/1/statuses/update_with_media.json", tweetParams, Tweet.class);
 	}
 
@@ -263,6 +289,7 @@ class TimelineTemplate extends AbstractTwitterOperations implements TimelineOper
 	public List<Tweet> getRetweets(long tweetId, int count) {
 		MultiValueMap<String, String> parameters = new LinkedMultiValueMap<String, String>();
 		parameters.set("count", String.valueOf(count));
+        parameters.putAll(this.buildParameters());
 		return restTemplate.getForObject(buildUri("statuses/retweets/" + tweetId + ".json", parameters), TweetList.class);
 	}
 
@@ -272,6 +299,7 @@ class TimelineTemplate extends AbstractTwitterOperations implements TimelineOper
 
 	public List<TwitterProfile> getRetweetedBy(long tweetId, int page, int pageSize) {
 		MultiValueMap<String, String> parameters = PagingUtils.buildPagingParametersWithCount(page, pageSize, 0, 0);
+        parameters.putAll(this.buildParameters());
 		return restTemplate.getForObject(buildUri("statuses/" + tweetId + "/retweeted_by.json", parameters), TwitterProfileList.class);
 	}
 
@@ -282,10 +310,12 @@ class TimelineTemplate extends AbstractTwitterOperations implements TimelineOper
 	public List<Long> getRetweetedByIds(long tweetId, int page, int pageSize) {
 		requireAuthorization(); // requires authentication, even though getRetweetedBy() does not.
 		MultiValueMap<String, String> parameters = PagingUtils.buildPagingParametersWithCount(page, pageSize, 0, 0);
+        parameters.putAll(this.buildParameters());
 		return restTemplate.getForObject(buildUri("statuses/" + tweetId + "/retweeted_by/ids.json", parameters), LongList.class);
 	}
 
-	public List<Tweet> getFavorites() {
+
+    public List<Tweet> getFavorites() {
 		return getFavorites(1, 20);
 	}
 
@@ -293,6 +323,7 @@ class TimelineTemplate extends AbstractTwitterOperations implements TimelineOper
 		requireAuthorization();
 		// Note: The documentation for /favorites.json doesn't list the count parameter, but it works anyway.
 		MultiValueMap<String, String> parameters = PagingUtils.buildPagingParametersWithCount(page, pageSize, 0, 0);
+        parameters.putAll(this.buildParameters());
 		return restTemplate.getForObject(buildUri("favorites.json", parameters), TweetList.class);
 	}
 
@@ -307,6 +338,17 @@ class TimelineTemplate extends AbstractTwitterOperations implements TimelineOper
 		MultiValueMap<String, Object> data = new LinkedMultiValueMap<String, Object>();
 		restTemplate.postForObject(buildUri("favorites/destroy/" + tweetId + ".json"), data, String.class);
 	}
+
+
+    private MultiValueMap<String, String> buildParameters()
+    {
+        final MultiValueMap<String, String> parameters = new LinkedMultiValueMap<String, String>();
+        if (this.includeEntities)
+        {
+            parameters.set("include_entities", "true");
+        }
+        return parameters;
+    }
 
 	@SuppressWarnings("serial")
 	private static class LongList extends ArrayList<Long>{}

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/TweetDeserializer.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/TweetDeserializer.java
@@ -15,6 +15,15 @@
  */
 package org.springframework.social.twitter.api.impl;
 
+import org.codehaus.jackson.JsonNode;
+import org.codehaus.jackson.JsonParser;
+import org.codehaus.jackson.map.DeserializationContext;
+import org.codehaus.jackson.map.JsonDeserializer;
+import org.codehaus.jackson.map.ObjectMapper;
+import org.springframework.social.twitter.api.Entities;
+import org.springframework.social.twitter.api.Tweet;
+import org.springframework.social.twitter.api.TwitterProfile;
+
 import java.io.IOException;
 import java.text.DateFormat;
 import java.text.ParseException;
@@ -22,72 +31,167 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Locale;
 
-import org.codehaus.jackson.JsonNode;
-import org.codehaus.jackson.JsonParser;
-import org.codehaus.jackson.JsonProcessingException;
-import org.codehaus.jackson.map.DeserializationContext;
-import org.codehaus.jackson.map.JsonDeserializer;
-import org.springframework.social.twitter.api.Tweet;
-
 /**
  * Custom Jackson deserializer for tweets. Tweets can't be simply mapped like other Twitter model objects because the JSON structure
  * varies between the search API and the timeline API. This deserializer determine which structure is in play and creates a tweet from it.
+ *
  * @author Craig Walls
  */
-class TweetDeserializer extends JsonDeserializer<Tweet> {
+class TweetDeserializer extends JsonDeserializer<Tweet>
+{
+    @Override
+    public Tweet deserialize(final JsonParser jp, final DeserializationContext ctx) throws IOException
+    {
+        final JsonNode tree = jp.readValueAsTree();
+        if (null == tree || tree.isMissingNode() || tree.isNull())
+        {
+            return null;
+        }
+        final Tweet tweet = this.deserialize(tree);
+        jp.skipChildren();
+        return tweet;
+    }
 
-	@Override
-	public Tweet deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException, JsonProcessingException {
-		JsonNode tree = jp.readValueAsTree();
-		long id = tree.get("id").asLong();
-		String text = tree.get("text").asText();
-		JsonNode fromUserNode = tree.get("user");
-		String fromScreenName = null;
-		long fromId = 0;
-		String fromImageUrl = null;
-		String dateFormat = TIMELINE_DATE_FORMAT;
-		if (fromUserNode != null) {
-			fromScreenName = fromUserNode.get("screen_name").asText();
-			fromId = fromUserNode.get("id").asLong();
-			fromImageUrl = fromUserNode.get("profile_image_url").asText();
-		} else {
-			fromScreenName = tree.get("from_user").asText();
-			fromId = tree.get("from_user_id").asLong();
-			fromImageUrl = tree.get("profile_image_url").asText();
-			dateFormat = SEARCH_DATE_FORMAT;
-		}
-		Date createdAt = toDate(tree.get("created_at").asText(), new SimpleDateFormat(dateFormat, Locale.ENGLISH));
-		String source = tree.get("source").asText();
-		JsonNode toUserIdNode = tree.get("in_reply_to_user_id");
-		Long toUserId = toUserIdNode != null ? toUserIdNode.getLongValue() : null;
-		JsonNode languageCodeNode = tree.get("iso_language_code");
-		String languageCode = languageCodeNode != null ? languageCodeNode.asText() : null;
-		Tweet tweet = new Tweet(id, text, createdAt, fromScreenName, fromImageUrl, toUserId, fromId, languageCode, source);
-		JsonNode inReplyToStatusIdNode = tree.get("in_reply_to_status_id");
-		Long inReplyToStatusId = inReplyToStatusIdNode != null && !inReplyToStatusIdNode.isNull() ? inReplyToStatusIdNode.getLongValue() : null;
-		tweet.setInReplyToStatusId(inReplyToStatusId);
-		JsonNode retweetCountNode = tree.get("retweet_count");
-		Integer retweetCount = retweetCountNode != null && !retweetCountNode.isNull() ? retweetCountNode.getIntValue() : null;
-		tweet.setRetweetCount(retweetCount);
-		jp.skipChildren();
-		return tweet;
-	}
-	
-    private Date toDate(String dateString, DateFormat dateFormat) {
-        if (dateString == null) {
+
+    public Tweet deserialize(final JsonNode tree) throws IOException
+    {
+        if (null == tree || tree.isMissingNode() || tree.isNull())
+        {
             return null;
         }
 
-        try {
+        final Long id = tree.path("id").asLong();
+        final String text = tree.path("text").asText();
+        if (null == id || null == text)
+        {
+            throw new IOException("Unable to determine tweet id or text.");
+        }
+
+        final JsonNode fromUserNode = tree.get("user");
+        final String fromScreenName;
+        final long fromId;
+        final String fromImageUrl;
+        String dateFormat = TIMELINE_DATE_FORMAT;
+        if (fromUserNode != null)
+        {
+            fromScreenName = fromUserNode.get("screen_name").asText();
+            fromId = fromUserNode.get("id").asLong();
+            fromImageUrl = fromUserNode.get("profile_image_url").asText();
+        }
+        else
+        {
+            fromScreenName = tree.get("from_user").asText();
+            fromId = tree.get("from_user_id").asLong();
+            fromImageUrl = tree.get("profile_image_url").asText();
+            dateFormat = SEARCH_DATE_FORMAT;
+        }
+        Date createdAt = toDate(tree.get("created_at").asText(), new SimpleDateFormat(dateFormat, Locale.ENGLISH));
+        Long toUserId = toLong(tree.get("in_reply_to_user_id"));
+        Long inReplyToStatusId = toLong(tree.path("in_reply_to_status_id"));
+        String toUserName = toString(tree.path("in_reply_to_screen_name"));
+        String languageCode = toString(tree.path("iso_language_code"));
+        String source = toString(tree.path("source"));
+        Integer retweetedCount = toInteger(tree.path("retweet_count"));
+        boolean retweetedByMe = toBoolean(tree.path("current_user_retweet"));
+        boolean truncated = toBoolean(tree.path("truncated"));
+        boolean favorited = toBoolean(tree.path("favorited"));
+        JsonNode retweetedNode = tree.get("retweeted_status");
+        Tweet retweetedStatus = retweetedNode != null ? this.deserialize(retweetedNode) : null;
+        Entities entities = toEntities(tree.get("entities"));
+        TwitterProfile user = toProfile(fromUserNode);
+        return new Tweet(id, text, createdAt, fromId, fromScreenName, fromImageUrl, languageCode, toUserId, toUserName, inReplyToStatusId, source, retweetedCount, retweetedStatus, retweetedByMe, truncated, favorited, entities, retweetedStatus, user);
+    }
+
+
+    private ObjectMapper createMapper()
+    {
+        final ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule(new TwitterModule());
+        return mapper;
+    }
+
+
+    private TwitterProfile toProfile(final JsonNode node) throws IOException
+    {
+        if (null == node || node.isNull() || node.isMissingNode())
+        {
+            return null;
+        }
+        final ObjectMapper mapper = this.createMapper();
+        return mapper.readValue(node, TwitterProfile.class);
+    }
+
+
+    private Entities toEntities(final JsonNode node) throws IOException
+    {
+        if (null == node || node.isNull() || node.isMissingNode())
+        {
+            return null;
+        }
+        final ObjectMapper mapper = this.createMapper();
+        return mapper.readValue(node, Entities.class);
+    }
+
+
+    private boolean toBoolean(final JsonNode node)
+    {
+        if (null == node || node.isNull() || node.isMissingNode())
+        {
+            return false;
+        }
+        return node.asBoolean(false);
+    }
+
+
+    private Long toLong(final JsonNode node)
+    {
+        if (null == node || node.isNull() || node.isMissingNode())
+        {
+            return null;
+        }
+        return node.asLong();
+    }
+
+
+    private Integer toInteger(final JsonNode node)
+    {
+        if (null == node || node.isNull() || node.isMissingNode())
+        {
+            return null;
+        }
+        return node.asInt();
+    }
+
+
+    private String toString(final JsonNode node)
+    {
+        if (null == node || node.isNull() || node.isMissingNode())
+        {
+            return null;
+        }
+        return node.asText();
+    }
+
+
+    private Date toDate(String dateString, DateFormat dateFormat)
+    {
+        if (dateString == null || dateString.isEmpty())
+        {
+            return null;
+        }
+
+        try
+        {
             return dateFormat.parse(dateString);
-        } catch (ParseException e) {
+        }
+        catch (ParseException e)
+        {
             return null;
         }
     }
 
 
-	private static final String TIMELINE_DATE_FORMAT = "EEE MMM dd HH:mm:ss ZZZZZ yyyy";
+    private static final String TIMELINE_DATE_FORMAT = "EEE MMM dd HH:mm:ss ZZZZZ yyyy";
 
-	private static final String SEARCH_DATE_FORMAT = "EEE, d MMM yyyy HH:mm:ss Z";
-
+    private static final String SEARCH_DATE_FORMAT = "EEE, d MMM yyyy HH:mm:ss Z";
 }

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/TwitterTemplate.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/TwitterTemplate.java
@@ -74,9 +74,10 @@ public class TwitterTemplate extends AbstractOAuth1ApiBinding implements Twitter
 	 * Any operations requiring authentication will throw {@link NotAuthorizedException} .
 	 */
 	public TwitterTemplate() {
-		super();
-		initSubApis();
+        super();
+        initSubApis(false);
 	}
+
 
 	/**
 	 * Create a new instance of TwitterTemplate.
@@ -86,10 +87,24 @@ public class TwitterTemplate extends AbstractOAuth1ApiBinding implements Twitter
 	 * @param accessTokenSecret an access token secret acquired through OAuth authentication with Twitter
 	 */
 	public TwitterTemplate(String consumerKey, String consumerSecret, String accessToken, String accessTokenSecret) {
-		super(consumerKey, consumerSecret, accessToken, accessTokenSecret);
-		initSubApis();
+		this(consumerKey, consumerSecret, accessToken, accessTokenSecret, false);
 	}
-	
+
+
+    /**
+     * Create a new instance of TwitterTemplate.
+     * @param consumerKey the application's API key
+     * @param consumerSecret the application's API secret
+     * @param accessToken an access token acquired through OAuth authentication with Twitter
+     * @param accessTokenSecret an access token secret acquired through OAuth authentication with Twitter
+     * @param includeEntities include timeline entities, see https://dev.twitter.com/docs/tweet-entities
+     */
+    public TwitterTemplate(String consumerKey, String consumerSecret, String accessToken, String accessTokenSecret, boolean includeEntities) {
+        super(consumerKey, consumerSecret, accessToken, accessTokenSecret);
+        initSubApis(includeEntities);
+    }
+
+
 	public TimelineOperations timelineOperations() {
 		return timelineOperations;
 	}
@@ -144,15 +159,14 @@ public class TwitterTemplate extends AbstractOAuth1ApiBinding implements Twitter
 	
 	// private helper 
 
-	private void initSubApis() {
+	private void initSubApis(final boolean includeEntities) {
 		this.userOperations = new UserTemplate(getRestTemplate(), isAuthorized());
 		this.directMessageOperations = new DirectMessageTemplate(getRestTemplate(), isAuthorized());
 		this.friendOperations = new FriendTemplate(getRestTemplate(), isAuthorized());
 		this.listOperations = new ListTemplate(getRestTemplate(), isAuthorized());
-		this.timelineOperations = new TimelineTemplate(getRestTemplate(), isAuthorized());
-		this.searchOperations = new SearchTemplate(getRestTemplate(), isAuthorized());
+		this.timelineOperations = new TimelineTemplate(getRestTemplate(), isAuthorized(), includeEntities);
+		this.searchOperations = new SearchTemplate(getRestTemplate(), isAuthorized(), includeEntities);
 		this.blockOperations = new BlockTemplate(getRestTemplate(), isAuthorized());
 		this.geoOperations = new GeoTemplate(getRestTemplate(), isAuthorized());
 	}
-
 }


### PR DESCRIPTION
- exposed include_entities parameter for timeline/search api
- exposed embedded retweet, user profile json to tweet object
- updated tweet deserializer logic to handle embedded json tree
- added proper equals/hashcode to core tweet, user profile objects
- tweet object is now serializable
