### PR TITLE
Search does not require authorization

### DIFF
--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/SearchTemplate.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/SearchTemplate.java
@@ -59,7 +59,6 @@ class SearchTemplate extends AbstractTwitterOperations implements SearchOperatio
 	}
 
 	public SearchResults search(SearchParameters searchParameters) {
-		requireAuthorization();
 		Assert.notNull(searchParameters);
 		MultiValueMap<String, String> parameters = buildQueryParametersFromSearchParameters(searchParameters);
 		return restTemplate.getForObject(buildUri("search/tweets.json", parameters),SearchResults.class);


### PR DESCRIPTION
...itter/api/impl/SearchTemplate.java

Search request does not require authorization.

This is as-per the last line of
https://dev.twitter.com/docs/auth/oauth#user-context

_The Search API supports only unauthenticated requests._
