### PR TITLE
id_str added to tweet class

### DIFF
--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/TimelineOperations.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/TimelineOperations.java
@@ -232,7 +232,7 @@ public interface TimelineOperations {
 	 * @throws ApiException if there is an error while communicating with Twitter.
 	 * @throws MissingAuthorizationException if TwitterTemplate was not created with OAuth credentials or an application access token.
 	 */
-	OEmbedTweet getStatusOEmbed(long tweetId);
+	OEmbedTweet getStatusOEmbed(String tweetId);
 
 	/**
 	 * Returns a single tweet as an oEmbed representation.
@@ -242,7 +242,7 @@ public interface TimelineOperations {
 	 * @throws ApiException if there is an error while communicating with Twitter.
 	 * @throws MissingAuthorizationException if TwitterTemplate was not created with OAuth credentials or an application access token.
 	 */
-	OEmbedTweet getStatusOEmbed(long tweetId, OEmbedOptions options);
+	OEmbedTweet getStatusOEmbed(String tweetId, OEmbedOptions options);
 
 	/**
 	 * Updates the user's status.

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/Tweet.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/Tweet.java
@@ -26,6 +26,7 @@ public class Tweet extends TwitterObject implements Serializable {
 	private static final long serialVersionUID = 1L;
 
 	private final long id;
+	private final String idStr;
 	private final String text;
 	private final Date createdAt;
 	private String fromUser;
@@ -45,8 +46,9 @@ public class Tweet extends TwitterObject implements Serializable {
 	private Entities entities;
 	private TwitterProfile user;
 
-	public Tweet(long id, String text, Date createdAt, String fromUser, String profileImageUrl, Long toUserId, long fromUserId, String languageCode, String source) {
+	public Tweet(long id, String idStr, String text, Date createdAt, String fromUser, String profileImageUrl, Long toUserId, long fromUserId, String languageCode, String source) {
 		this.id = id;
+		this.idStr = idStr;
 		this.text = text;
 		this.createdAt = createdAt;
 		this.fromUser = fromUser;
@@ -90,6 +92,10 @@ public class Tweet extends TwitterObject implements Serializable {
 
 	public long getId() {
 		return id;
+	}
+
+	public String getIdStr() {
+		return idStr;
 	}
 
 	public String getProfileImageUrl() {
@@ -266,6 +272,9 @@ public class Tweet extends TwitterObject implements Serializable {
 		if (id != tweet.id) {
 			return false;
 		}
+		if (idStr != null ? !idStr.equals(tweet.idStr) : tweet.idStr != null) {
+			return false;
+		}
 		if (retweeted != tweet.retweeted) {
 			return false;
 		}
@@ -318,6 +327,7 @@ public class Tweet extends TwitterObject implements Serializable {
 	@Override
 	public int hashCode() {
 		int result = (int) (id ^ (id >>> 32));
+		result = 31 * result + (idStr != null ? idStr.hashCode() : 0);
 		result = 31 * result + (text != null ? text.hashCode() : 0);
 		result = 31 * result + (createdAt != null ? createdAt.hashCode() : 0);
 		result = 31 * result + (fromUser != null ? fromUser.hashCode() : 0);

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/TimelineTemplate.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/TimelineTemplate.java
@@ -141,11 +141,11 @@ class TimelineTemplate extends AbstractTwitterOperations implements TimelineOper
 		return restTemplate.getForObject(buildUri("statuses/show/" + tweetId + ".json", parameters), Tweet.class);
 	}
 	
-	public OEmbedTweet getStatusOEmbed(long tweetId) {
+	public OEmbedTweet getStatusOEmbed(String tweetId) {
 		return getStatusOEmbed(tweetId, new OEmbedOptions());
 	}
 	
-	public OEmbedTweet getStatusOEmbed(long tweetId, OEmbedOptions options) {
+	public OEmbedTweet getStatusOEmbed(String tweetId, OEmbedOptions options) {
 		requireEitherUserOrAppAuthorization();
 		MultiValueMap<String, String> parameters = options.toRequestParameters();
 		parameters.set("id", String.valueOf(tweetId));

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/TweetDeserializer.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/TweetDeserializer.java
@@ -58,6 +58,7 @@ class TweetDeserializer extends JsonDeserializer<Tweet> {
 
 	public Tweet deserialize(JsonNode node) throws IOException, JsonProcessingException {
 		final long id = node.path("id").asLong();
+		final String idStr = node.path("id_str").asText();
 		final String text = node.path("text").asText();
 		if (id <= 0 || text == null || text.isEmpty()) {
 			return null;
@@ -72,7 +73,7 @@ class TweetDeserializer extends JsonDeserializer<Tweet> {
 		JsonNode toUserIdNode = node.get("in_reply_to_user_id");
 		Long toUserId = toUserIdNode != null ? toUserIdNode.asLong() : null;
 		String languageCode = node.get("lang").asText();
-		Tweet tweet = new Tweet(id, text, createdAt, fromScreenName, fromImageUrl, toUserId, fromId, languageCode, source);
+		Tweet tweet = new Tweet(id, idStr, text, createdAt, fromScreenName, fromImageUrl, toUserId, fromId, languageCode, source);
 		JsonNode inReplyToStatusIdNode = node.get("in_reply_to_status_id");
 		Long inReplyToStatusId = inReplyToStatusIdNode != null && !inReplyToStatusIdNode.isNull() ? inReplyToStatusIdNode.asLong() : null;
 		tweet.setInReplyToStatusId(inReplyToStatusId);

--- a/spring-social-twitter/src/test/java/org/springframework/social/twitter/api/impl/TimelineTemplateTest.java
+++ b/spring-social-twitter/src/test/java/org/springframework/social/twitter/api/impl/TimelineTemplateTest.java
@@ -316,7 +316,7 @@ public class TimelineTemplateTest extends AbstractTwitterApiTest {
 			.andExpect(method(GET))
 			.andRespond(withSuccess(jsonResource("oembed"), APPLICATION_JSON));
 
-		OEmbedTweet oembed = twitter.timelineOperations().getStatusOEmbed(357251561744916480L);
+		OEmbedTweet oembed = twitter.timelineOperations().getStatusOEmbed(String.valueOf(357251561744916480L));
 		assertOEmbedTweet(oembed);
 	}
 
@@ -326,7 +326,7 @@ public class TimelineTemplateTest extends AbstractTwitterApiTest {
 			.andExpect(method(GET))
 			.andRespond(withSuccess(jsonResource("oembed"), APPLICATION_JSON));
 
-		OEmbedTweet oembed = twitter.timelineOperations().getStatusOEmbed(357251561744916480L, 
+		OEmbedTweet oembed = twitter.timelineOperations().getStatusOEmbed(String.valueOf(357251561744916480L), 
 				new OEmbedOptions().maxWidth(300)
 								   .hideMedia()
 								   .hideThread()
@@ -677,6 +677,7 @@ public class TimelineTemplateTest extends AbstractTwitterApiTest {
 	// private helper
 	private Resource getUploadResource(final String filename, String content) {
 		Resource resource = new ByteArrayResource(content.getBytes()) {
+			@Override
 			public String getFilename() throws IllegalStateException {
 				return filename;
 			};


### PR DESCRIPTION
Tweet class contains the id (as long) but not the more important id_str (as string). id_str is needed to create a link to a single tweet.