### PR TITLE
Use the latest version of the Spring IO Plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         classpath 'me.champeau.gradle:gradle-javadoc-hotfix-plugin:0.1'
         classpath('org.asciidoctor:asciidoctor-gradle-plugin:0.7.0')
         classpath('org.asciidoctor:asciidoctor-java-integration:0.1.4.preview.1')
-        classpath('org.springframework.build.gradle:spring-io-plugin:0.0.3.RELEASE')
+        classpath('io.spring.gradle:spring-io-plugin:0.0.4.RELEASE')
     }
 }
 
@@ -55,7 +55,7 @@ configure(allprojects - docProjects) {
     ]
 
     sourceSets.test.resources.srcDirs = [
-        "src/test/resources", 
+        "src/test/resources",
         "src/test/java"
     ]
 
@@ -98,8 +98,12 @@ configure(subprojects - docProjects) { subproject ->
             maven { url "https://repo.spring.io/libs-snapshot" }
         }
 
-        dependencies {
-            springIoVersions "io.spring.platform:platform-versions:${platformVersion}@properties"
+        dependencyManagement {
+            springIoTestRuntime {
+                imports {
+                    mavenBom "io.spring.platform:platform-bom:${platformVersion}"
+                }
+            }
         }
     }
 
@@ -214,7 +218,7 @@ configure(rootProject) {
 
     dependencies { // for integration tests
     }
-    
+
     task api(type: Javadoc) {
         group = "Documentation"
         description = "Generates aggregated Javadoc API documentation."
@@ -268,7 +272,7 @@ configure(rootProject) {
         archives dist
         archives project(':docs').docsZip
         archives project(':docs').schemaZip
-    }    
+    }
 
     task wrapper(type: Wrapper) {
         gradleVersion = '1.12'


### PR DESCRIPTION
This change is necessary to allow Spring IO Platform 2.0 to remove the platform-versions properties file that was deprecated in 1.1. To allow Spring Social Twitter's Platform compliance to be verified as part of Spring IO Platform 2.0's build and release process, I'd like this to be included in Spring Social Twitter 1.1.x which is the version that's currently in Spring IO Platform 2.0. If you have any questions, please let me know.