### PR TITLE
SOCIAL-483: Add support for non-Tweet stream events

### DIFF
--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/StreamListener.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/StreamListener.java
@@ -15,6 +15,8 @@
  */
 package org.springframework.social.twitter.api;
 
+import java.util.Map;
+
 /**
  * Listener interface for clients consuming data from a Twitter stream.
  * @author Craig Walls
@@ -44,5 +46,6 @@ public interface StreamListener {
 	 * @param warningEvent a warning event
 	 */
 	void onWarning(StreamWarningEvent warningEvent);
-	
+
+	void onEvent(Map event);
 }

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/StreamDispatcher.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/StreamDispatcher.java
@@ -17,6 +17,7 @@ package org.springframework.social.twitter.api.impl;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 import java.util.Queue;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -69,6 +70,8 @@ class StreamDispatcher implements Runnable {
 					handleDelete(line);
 				} else if (line.startsWith("{\"warning")) {
 					handleWarning(line);
+				} else {
+					handleEvent(line);
 				}
 			} catch (IOException e) {
 				// TODO: Should only happen if Jackson doesn't know how to map the line
@@ -120,6 +123,17 @@ class StreamDispatcher implements Runnable {
 			Future<?> result = pool.submit((new Runnable() {
 				public void run() {
 					listener.onWarning(warningEvent);
+				}
+			}));
+		}
+	}
+
+	private void handleEvent(String line) throws IOException {
+		final Map event = objectMapper.readValue(line, Map.class);
+		for (final StreamListener listener : listeners) {
+			Future<?> result = pool.submit((new Runnable() {
+				public void run() {
+					listener.onEvent(event);
 				}
 			}));
 		}

--- a/spring-social-twitter/src/test/java/org/springframework/social/twitter/api/impl/StreamingTemplateTest.java
+++ b/spring-social-twitter/src/test/java/org/springframework/social/twitter/api/impl/StreamingTemplateTest.java
@@ -24,6 +24,7 @@ import static org.springframework.test.web.client.response.MockRestResponseCreat
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
 import org.junit.Ignore;
 import org.junit.Test;
@@ -111,6 +112,11 @@ public class StreamingTemplateTest extends AbstractTwitterApiTest {
 		
 		public void onWarning(StreamWarningEvent warningEvent) {
 			warningsReceived.add(warningEvent);
+			messageReceived();
+		}
+
+		@Override
+		public void onEvent(Map event) {
 			messageReceived();
 		}
 


### PR DESCRIPTION
This is a very basic implementation, but you get the idea. The method returns a `Map` so then the client, can say `((Map<String, String>) event.get("source")).get("screen_name");` for example.