### PR TITLE
Take into account that a tweet's lang is nullable

### DIFF
--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/TweetDeserializer.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/TweetDeserializer.java
@@ -72,7 +72,8 @@ class TweetDeserializer extends JsonDeserializer<Tweet> {
 		String source = node.get("source").asText();
 		JsonNode toUserIdNode = node.get("in_reply_to_user_id");
 		Long toUserId = toUserIdNode != null ? toUserIdNode.asLong() : null;
-		String languageCode = node.get("lang").asText();
+		JsonNode languageCodeNode = node.get("lang");
+		String languageCode = languageCodeNode != null && !languageCodeNode.isNull() ? languageCodeNode.asText() : null;
 		Tweet tweet = new Tweet(id, idStr, text, createdAt, fromScreenName, fromImageUrl, toUserId, fromId, languageCode, source);
 		JsonNode inReplyToStatusIdNode = node.get("in_reply_to_status_id");
 		Long inReplyToStatusId = inReplyToStatusIdNode != null && !inReplyToStatusIdNode.isNull() ? inReplyToStatusIdNode.asLong() : null;


### PR DESCRIPTION
Hi,

I recently had a few stacktraces like this when retrieving users' most recent tweets:

```
org.springframework.http.converter.HttpMessageNotReadableException: Could not read document: (was java.lang.NullPointerException) (through reference chain: org.springframework.social.twitter.api.impl.TweetList[89]); nested exception is com.fasterxml.jackson.databind.JsonMappingException: (was java.lang.NullPointerException) (through reference chain: org.springframework.social.twitter.api.impl.TweetList[89])
  at org.springframework.http.converter.json.AbstractJackson2HttpMessageConverter.readJavaType(AbstractJackson2HttpMessageConverter.java:229)
  at org.springframework.http.converter.json.AbstractJackson2HttpMessageConverter.read(AbstractJackson2HttpMessageConverter.java:213)
  at org.springframework.web.client.HttpMessageConverterExtractor.extractData(HttpMessageConverterExtractor.java:95)
  at org.springframework.web.client.RestTemplate.doExecute(RestTemplate.java:599)
  at org.springframework.web.client.RestTemplate.execute(RestTemplate.java:572)
  at org.springframework.web.client.RestTemplate.getForObject(RestTemplate.java:280)
  at org.springframework.social.twitter.api.impl.TimelineTemplate.getUserTimeline(TimelineTemplate.java:107)
  at org.springframework.social.twitter.api.impl.TimelineTemplate.getUserTimeline(TimelineTemplate.java:99)
  [...]
Caused by: com.fasterxml.jackson.databind.JsonMappingException: (was java.lang.NullPointerException) (through reference chain: org.springframework.social.twitter.api.impl.TweetList[89])
  at com.fasterxml.jackson.databind.JsonMappingException.wrapWithPath(JsonMappingException.java:210)
  at com.fasterxml.jackson.databind.JsonMappingException.wrapWithPath(JsonMappingException.java:189)
  at com.fasterxml.jackson.databind.deser.std.CollectionDeserializer.deserialize(CollectionDeserializer.java:266)
  at com.fasterxml.jackson.databind.deser.std.CollectionDeserializer.deserialize(CollectionDeserializer.java:217)
  at com.fasterxml.jackson.databind.deser.std.CollectionDeserializer.deserialize(CollectionDeserializer.java:25)
  at com.fasterxml.jackson.databind.ObjectMapper._readMapAndClose(ObjectMapper.java:3736)
  at com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:2810)
  at org.springframework.http.converter.json.AbstractJackson2HttpMessageConverter.readJavaType(AbstractJackson2HttpMessageConverter.java:226)
  ... 24 more
Caused by: java.lang.NullPointerException
  at org.springframework.social.twitter.api.impl.TweetDeserializer.deserialize(TweetDeserializer.java:75)
  at org.springframework.social.twitter.api.impl.TweetDeserializer.deserialize(TweetDeserializer.java:53)
  at org.springframework.social.twitter.api.impl.TweetDeserializer.deserialize(TweetDeserializer.java:45)
  at com.fasterxml.jackson.databind.deser.std.CollectionDeserializer.deserialize(CollectionDeserializer.java:245)
  ... 29 more
```

Turns out that a tweet's lang is nullable [according to the docs](https://dev.twitter.com/overview/api/tweets).

In my case the JsonNode was `null` (hence the NPE) but I also added a check for `JsonNode#isNull`. Without this last check, `NullNode#asText` would return the String `"null"`, so I thought it would probably be cleaner to return a real `null`.

*I signed the CLA with the same email address as the one used in the commit.*

Cheers,
Pablo