### PR TITLE
Support for Direct messages

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Jul 05 16:20:09 CEST 2016
+#Wed Jun 18 11:11:02 CDT 2014
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.12-all.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-1.12-bin.zip

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Jun 18 11:11:02 CDT 2014
+#Tue Jul 05 16:20:09 CEST 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.12-bin.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-1.12-all.zip

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/StreamListener.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/StreamListener.java
@@ -44,5 +44,10 @@ public interface StreamListener {
 	 * @param warningEvent a warning event
 	 */
 	void onWarning(StreamWarningEvent warningEvent);
-	
+
+	/**
+	 * Called when a new  {@link DirectMessage} is available on the stream
+	 * @param directMessage
+     */
+	void onDirectMessage(DirectMessage directMessage);
 }

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/StreamingOperations.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/StreamingOperations.java
@@ -71,4 +71,13 @@ public interface StreamingOperations {
 	
 	Stream user(UserStreamParameters parameters, List<StreamListener> listeners);
 
+	/**
+	 * Monitor a user stream.
+	 *
+	 * @param parameters the parameters for the user stream
+	 * @param listeners the listener's to monitor the stream
+	 * @param bufferSize the buffer size to use for the underlying stream. Use a lower value if you encounter buffering on low volume streams.
+     * @return the user stream
+     */
+	Stream user(final UserStreamParameters parameters, final List<StreamListener> listeners, final int bufferSize);
 }

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/DirectMessageMixin.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/DirectMessageMixin.java
@@ -17,7 +17,6 @@ package org.springframework.social.twitter.api.impl;
 
 import java.util.Date;
 
-import com.fasterxml.jackson.annotation.JsonRootName;
 import org.springframework.social.twitter.api.TwitterProfile;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -31,11 +30,11 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 abstract class DirectMessageMixin extends TwitterObjectMixin {
-
+	@JsonCreator
 	DirectMessageMixin(
-			@JsonProperty("id") long id, 
-			@JsonProperty("text") String text, 
-			@JsonProperty("sender") TwitterProfile sender, 
-			@JsonProperty("recipient") TwitterProfile receipient, 
+			@JsonProperty("id") long id,
+			@JsonProperty("text") String text,
+			@JsonProperty("sender") TwitterProfile sender,
+			@JsonProperty("recipient") TwitterProfile receipient,
 			@JsonProperty("created_at") @JsonDeserialize(using=TimelineDateDeserializer.class) Date createdAt) {}
 }

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/DirectMessageMixin.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/DirectMessageMixin.java
@@ -17,6 +17,7 @@ package org.springframework.social.twitter.api.impl;
 
 import java.util.Date;
 
+import com.fasterxml.jackson.annotation.JsonRootName;
 import org.springframework.social.twitter.api.TwitterProfile;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -30,7 +31,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 abstract class DirectMessageMixin extends TwitterObjectMixin {
-	@JsonCreator
+
 	DirectMessageMixin(
 			@JsonProperty("id") long id, 
 			@JsonProperty("text") String text, 

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/DirectMessageMixin.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/DirectMessageMixin.java
@@ -17,12 +17,12 @@ package org.springframework.social.twitter.api.impl;
 
 import java.util.Date;
 
-import org.springframework.social.twitter.api.TwitterProfile;
-
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+import org.springframework.social.twitter.api.TwitterProfile;
 
 /**
  * Mixin class for adding Jackson annotations to DirectMessage.

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/StreamDispatcher.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/StreamDispatcher.java
@@ -15,16 +15,6 @@
  */
 package org.springframework.social.twitter.api.impl;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.springframework.social.twitter.api.DirectMessage;
-import org.springframework.social.twitter.api.StreamDeleteEvent;
-import org.springframework.social.twitter.api.StreamListener;
-import org.springframework.social.twitter.api.StreamWarningEvent;
-import org.springframework.social.twitter.api.Tweet;
-import org.springframework.social.twitter.api.TwitterProfile;
-
 import java.io.IOException;
 import java.util.List;
 import java.util.Queue;
@@ -32,6 +22,17 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.springframework.social.twitter.api.DirectMessage;
+import org.springframework.social.twitter.api.StreamDeleteEvent;
+import org.springframework.social.twitter.api.StreamListener;
+import org.springframework.social.twitter.api.StreamWarningEvent;
+import org.springframework.social.twitter.api.Tweet;
+import org.springframework.social.twitter.api.TwitterProfile;
 
 class StreamDispatcher implements Runnable {
 

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/StreamReaderImpl.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/StreamReaderImpl.java
@@ -15,6 +15,8 @@
  */
 package org.springframework.social.twitter.api.impl;
 
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
@@ -24,11 +26,8 @@ import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.zip.GZIPInputStream;
 
-import org.springframework.social.twitter.api.Stream;
 import org.springframework.social.twitter.api.StreamListener;
 import org.springframework.social.twitter.api.StreamingException;
 
@@ -62,7 +61,7 @@ class StreamReaderImpl implements StreamReader {
 		queue = new ConcurrentLinkedQueue<String>();
 		dispatcher = new StreamDispatcher(queue, listeners);
 		executor = new ScheduledThreadPoolExecutor(10);
-		future = executor.scheduleAtFixedRate(dispatcher, 0, 10, TimeUnit.MILLISECONDS);
+		future = executor.scheduleAtFixedRate(dispatcher, 0, 10, MILLISECONDS);
 		open = new AtomicBoolean(true);
 	}
 	

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/StreamReaderImpl.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/StreamReaderImpl.java
@@ -47,9 +47,6 @@ class StreamReaderImpl implements StreamReader {
 	
 	private final ScheduledThreadPoolExecutor executor;
 
-	public StreamReaderImpl(InputStream inputStream, List<StreamListener> listeners) {
-		this(inputStream, listeners, 8192);
-	}
 
 	public StreamReaderImpl(InputStream inputStream, List<StreamListener> listeners, int bufferSize) {
 		this.inputStream = inputStream;

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/StreamingTemplate.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/StreamingTemplate.java
@@ -43,6 +43,9 @@ import org.springframework.web.client.RestTemplate;
  * @author Craig Walls
  */
 class StreamingTemplate extends AbstractTwitterOperations implements StreamingOperations {
+
+	//The defualt buffer size to use for the underlying buffered reader.
+	private static final int DEFAULT_BUFFERS_SIZE = 8192;
 	
 	private final RestTemplate restTemplate;
 					
@@ -109,11 +112,15 @@ class StreamingTemplate extends AbstractTwitterOperations implements StreamingOp
 	}
 	
 	public Stream user(final UserStreamParameters parameters, final List<StreamListener> listeners) {
+		return user(parameters, listeners, DEFAULT_BUFFERS_SIZE);
+	}
+
+	public Stream user(final UserStreamParameters parameters, final List<StreamListener> listeners, final int bufferSize) {
 		Assert.notNull(parameters, "StreamFilter may not be null");
 		Assert.notEmpty(listeners, "Listeners collection may not be null or empty");
 		Stream stream = new ThreadedStreamConsumer() {
 			protected StreamReader getStreamReader() throws StreamCreationException {
-				return createStream(HttpMethod.POST, USER_STREAM_URL, parameters.toParameterMap(), listeners, 4);
+				return createStream(HttpMethod.POST, USER_STREAM_URL, parameters.toParameterMap(), listeners, bufferSize);
 			}
 		};
 		stream.open();

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/StreamingTemplate.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/StreamingTemplate.java
@@ -113,20 +113,24 @@ class StreamingTemplate extends AbstractTwitterOperations implements StreamingOp
 		Assert.notEmpty(listeners, "Listeners collection may not be null or empty");
 		Stream stream = new ThreadedStreamConsumer() {
 			protected StreamReader getStreamReader() throws StreamCreationException {
-				return createStream(HttpMethod.POST, USER_STREAM_URL, parameters.toParameterMap(), listeners);
+				return createStream(HttpMethod.POST, USER_STREAM_URL, parameters.toParameterMap(), listeners, 4);
 			}
 		};
 		stream.open();
 		return stream;
 	}
-	
+
 	private StreamReader createStream(HttpMethod method, String streamUrl, MultiValueMap<String, String> body, List<StreamListener> listeners) throws StreamCreationException {
+		return createStream(method, streamUrl, body, listeners, 8192);
+	}
+
+	private StreamReader createStream(HttpMethod method, String streamUrl, MultiValueMap<String, String> body, List<StreamListener> listeners, int bufferSize) throws StreamCreationException {
 		try {
 			ClientHttpResponse response = executeRequest(method, streamUrl, body);
 			if (response.getStatusCode().value() > 200) {
 				throw new StreamCreationException("Unable to create stream", response.getStatusCode());
 			}
-			return new StreamReaderImpl(response.getBody(), listeners);
+			return new StreamReaderImpl(response.getBody(), listeners, bufferSize);
 		} catch (IOException e) {
 			throw new StreamCreationException("Unable to create stream.", e);
 		}

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/StreamingTemplate.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/StreamingTemplate.java
@@ -44,8 +44,8 @@ import org.springframework.web.client.RestTemplate;
  */
 class StreamingTemplate extends AbstractTwitterOperations implements StreamingOperations {
 
-	//The defualt buffer size to use for the underlying buffered reader.
-	private static final int DEFAULT_BUFFERS_SIZE = 8192;
+	//The default buffer size to use for the underlying buffered reader.
+	private static final int DEFAULT_BUFFER_SIZE = 8192;
 	
 	private final RestTemplate restTemplate;
 					
@@ -112,7 +112,7 @@ class StreamingTemplate extends AbstractTwitterOperations implements StreamingOp
 	}
 	
 	public Stream user(final UserStreamParameters parameters, final List<StreamListener> listeners) {
-		return user(parameters, listeners, DEFAULT_BUFFERS_SIZE);
+		return user(parameters, listeners, DEFAULT_BUFFER_SIZE);
 	}
 
 	public Stream user(final UserStreamParameters parameters, final List<StreamListener> listeners, final int bufferSize) {
@@ -128,7 +128,7 @@ class StreamingTemplate extends AbstractTwitterOperations implements StreamingOp
 	}
 
 	private StreamReader createStream(HttpMethod method, String streamUrl, MultiValueMap<String, String> body, List<StreamListener> listeners) throws StreamCreationException {
-		return createStream(method, streamUrl, body, listeners, 8192);
+		return createStream(method, streamUrl, body, listeners, DEFAULT_BUFFER_SIZE);
 	}
 
 	private StreamReader createStream(HttpMethod method, String streamUrl, MultiValueMap<String, String> body, List<StreamListener> listeners, int bufferSize) throws StreamCreationException {

--- a/spring-social-twitter/src/test/java/org/springframework/social/twitter/api/impl/StreamImplTest.java
+++ b/spring-social-twitter/src/test/java/org/springframework/social/twitter/api/impl/StreamImplTest.java
@@ -35,7 +35,7 @@ public class StreamImplTest {
 	public void next() throws Exception {
 		StreamListener mockListener = mock(StreamListener.class);		
 		InputStream inputStream = new ClassPathResource("filter-stream-track.json", getClass()).getInputStream();
-		StreamReaderImpl stream = new StreamReaderImpl(inputStream, asList(mockListener));
+		StreamReaderImpl stream = new StreamReaderImpl(inputStream, asList(mockListener), 8192);
 		try {
 			while(true) {
 				stream.next();

--- a/spring-social-twitter/src/test/java/org/springframework/social/twitter/api/impl/StreamingTemplateTest.java
+++ b/spring-social-twitter/src/test/java/org/springframework/social/twitter/api/impl/StreamingTemplateTest.java
@@ -28,6 +28,7 @@ import java.util.List;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.springframework.core.io.ClassPathResource;
+import org.springframework.social.twitter.api.DirectMessage;
 import org.springframework.social.twitter.api.StreamDeleteEvent;
 import org.springframework.social.twitter.api.StreamListener;
 import org.springframework.social.twitter.api.StreamWarningEvent;
@@ -88,6 +89,7 @@ public class StreamingTemplateTest extends AbstractTwitterApiTest {
 		List<StreamDeleteEvent> deletesReceived = new ArrayList<StreamDeleteEvent>();
 		List<Integer> limitsReceived = new ArrayList<Integer>();
 		List<StreamWarningEvent> warningsReceived = new ArrayList<StreamWarningEvent>();
+		List<DirectMessage> directMessagesReceived = new ArrayList<>();
 		private int stopAfter = Integer.MAX_VALUE;
 		
 		public MockStreamListener(int stopAfter) {
@@ -114,6 +116,11 @@ public class StreamingTemplateTest extends AbstractTwitterApiTest {
 			messageReceived();
 		}
 
+		public void onDirectMessage(DirectMessage directMessage) {
+			directMessagesReceived.add(directMessage);
+			messageReceived();
+		}
+
 		private void messageReceived() {
 			stopAfter--;
 			if(stopAfter == 0) {
@@ -123,4 +130,6 @@ public class StreamingTemplateTest extends AbstractTwitterApiTest {
 		
 		protected abstract void shutdown();
 	}
+
+
 }


### PR DESCRIPTION
Hi guys,
I have an app which needs to send/receive direct messages from twitter. I added some support for that.  
I also added the buffer size as a param when setting up the Stream reader. Reason is that the messages got stuck in the buffer on low volume streams until enough traffic had arrived (roughly the same issue as described here https://dev.twitter.com/streaming/overview/processing 'Gzip and java').
Tell me what you think.
br Svante 