### PR TITLE
Fix for Issue #95 - Twitter userId is too large for JS serialization

### DIFF
--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/TwitterProfile.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/TwitterProfile.java
@@ -22,11 +22,13 @@ import java.util.Date;
  * Model class representing a Twitter user's profile information.
  * 
  * @author Craig Walls
+ * @author karthik
  */
 public class TwitterProfile extends TwitterObject implements Serializable {
 	private static final long serialVersionUID = 1L;
 
 	private final long id;
+	private final String idStr;
 	private final String screenName;
 	private final String name;
 	private final String url;
@@ -66,7 +68,12 @@ public class TwitterProfile extends TwitterObject implements Serializable {
 	}
 
 	public TwitterProfile(long id, String screenName, String name, String url, String profileImageUrl, String description, String location, Date createdDate) {
+		this(id, String.valueOf(id), screenName, name, url, profileImageUrl, description, location, createdDate);
+	}
+
+	public TwitterProfile(long id, String idStr, String screenName, String name, String url, String profileImageUrl, String description, String location, Date createdDate) {
 		this.id = id;
+		this.idStr = idStr;
 		this.screenName = screenName;
 		this.name = name;
 		this.url = url;
@@ -83,6 +90,15 @@ public class TwitterProfile extends TwitterObject implements Serializable {
 	 */
 	public long getId() {
 		return id;
+	}
+
+	/**
+	 * The user's Twitter ID in String format
+	 * 
+	 * @return The user's Twitter ID in String format
+	 */
+	public String getIdStr() {
+		return idStr;
 	}
 
 	/**
@@ -422,6 +438,9 @@ public class TwitterProfile extends TwitterObject implements Serializable {
 		if (verified != that.verified) {
 			return false;
 		}
+		if (idStr != null ? !idStr.equals(that.idStr) : that.idStr != null) {
+			return false;
+		}
 		if (backgroundColor != null ? !backgroundColor.equals(that.backgroundColor) : that.backgroundColor != null) {
 			return false;
 		}
@@ -475,6 +494,7 @@ public class TwitterProfile extends TwitterObject implements Serializable {
 	@Override
 	public int hashCode() {
 		int result = (int) (id ^ (id >>> 32));
+		result = 31 * result + (idStr != null ? idStr.hashCode() : 0);
 		result = 31 * result + (screenName != null ? screenName.hashCode() : 0);
 		result = 31 * result + (name != null ? name.hashCode() : 0);
 		result = 31 * result + (url != null ? url.hashCode() : 0);

--- a/spring-social-twitter/src/test/java/org/springframework/social/twitter/api/impl/UserTemplateTest.java
+++ b/spring-social-twitter/src/test/java/org/springframework/social/twitter/api/impl/UserTemplateTest.java
@@ -60,6 +60,7 @@ public class UserTemplateTest extends AbstractTwitterApiTest {
 
 		TwitterProfile profile = twitter.userOperations().getUserProfile();
 		assertEquals(161064614, profile.getId());
+		assertEquals("161064614", profile.getIdStr());
 		assertEquals("artnames", profile.getScreenName());
 		assertEquals("Art Names", profile.getName());
 		assertEquals("I'm just a normal kinda guy", profile.getDescription());
@@ -100,6 +101,7 @@ public class UserTemplateTest extends AbstractTwitterApiTest {
 
 		TwitterProfile profile = twitter.userOperations().getUserProfile(12345);
 		assertEquals(161064614, profile.getId());
+		assertEquals("161064614", profile.getIdStr());
 		assertEquals("artnames", profile.getScreenName());
 		assertEquals("Art Names", profile.getName());
 		assertEquals("I'm just a normal kinda guy", profile.getDescription());
@@ -117,6 +119,7 @@ public class UserTemplateTest extends AbstractTwitterApiTest {
 
 		TwitterProfile profile = appAuthTwitter.userOperations().getUserProfile(12345);
 		assertEquals(161064614, profile.getId());
+		assertEquals("161064614", profile.getIdStr());
 		assertEquals("artnames", profile.getScreenName());
 		assertEquals("Art Names", profile.getName());
 		assertEquals("I'm just a normal kinda guy", profile.getDescription());
@@ -133,6 +136,7 @@ public class UserTemplateTest extends AbstractTwitterApiTest {
 
 		TwitterProfile profile = twitter.userOperations().getUserProfile("artnames");
 		assertEquals(161064614, profile.getId());
+		assertEquals("161064614", profile.getIdStr());
 		assertEquals("artnames", profile.getScreenName());
 		assertEquals("Art Names", profile.getName());
 		assertEquals("I'm just a normal kinda guy", profile.getDescription());
@@ -150,6 +154,7 @@ public class UserTemplateTest extends AbstractTwitterApiTest {
 
 		TwitterProfile profile = appAuthTwitter.userOperations().getUserProfile("artnames");
 		assertEquals(161064614, profile.getId());
+		assertEquals("161064614", profile.getIdStr());
 		assertEquals("artnames", profile.getScreenName());
 		assertEquals("Art Names", profile.getName());
 		assertEquals("I'm just a normal kinda guy", profile.getDescription());


### PR DESCRIPTION
	Twitter provides id and id_str in User Object. Id is of datatype
	long and that could get too long for some programming languages
	to handle. For such languages, API is modified to return id in
	String format using the method getIdStr().
        More Info 
https://dev.twitter.com/overview/api/twitter-ids-json-and-snowflake