### PR TITLE
Update Tweet too long error message detection.

### DIFF
--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/DirectMessageOperations.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/DirectMessageOperations.java
@@ -109,7 +109,7 @@ public interface DirectMessageOperations {
 	 * @throws ApiException if there is an error while communicating with Twitter.
 	 * @throws InvalidMessageRecipientException if the recipient is not following the authenticating user.
 	 * @throws DuplicateStatusException if the message duplicates a previously sent message.
-	 * @throws MessageTooLongException if the message length exceeds Twitter's 140 character limit.
+	 * @throws MessageTooLongException if the message length exceeds Twitter's character limit.
 	 * @throws MissingAuthorizationException if TwitterTemplate was not created with OAuth credentials.
 	 */
 	DirectMessage sendDirectMessage(String toScreenName, String text);
@@ -125,7 +125,7 @@ public interface DirectMessageOperations {
 	 * @throws ApiException if there is an error while communicating with Twitter.
 	 * @throws InvalidMessageRecipientException if the recipient is not following the authenticating user.
 	 * @throws DuplicateStatusException if the message duplicates a previously sent message.
-	 * @throws MessageTooLongException if the message length exceeds Twitter's 140 character limit.
+	 * @throws MessageTooLongException if the message length exceeds Twitter's character limit.
 	 * @throws MissingAuthorizationException if TwitterTemplate was not created with OAuth credentials.
 	 */
 	DirectMessage sendDirectMessage(long toUserId, String text);

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/TimelineOperations.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/TimelineOperations.java
@@ -254,7 +254,7 @@ public interface TimelineOperations {
 	 * @return the Tweet object
 	 * @throws ApiException if there is an error while communicating with Twitter.
 	 * @throws DuplicateStatusException if the status message duplicates a previously posted status.
-	 * @throws MessageTooLongException if the length of the status message exceeds Twitter's 140 character limit.
+	 * @throws MessageTooLongException if the length of the status message exceeds Twitter's 280 character limit.
 	 * @throws MissingAuthorizationException if TwitterTemplate was not created with OAuth credentials.
 	 */
 	Tweet updateStatus(String status);
@@ -265,7 +265,7 @@ public interface TimelineOperations {
 	 * @return the Tweet object
 	 * @throws ApiException if there is an error while communicating with Twitter.
 	 * @throws DuplicateStatusException if the status message duplicates a previously posted status.
-	 * @throws MessageTooLongException if the length of the status message exceeds Twitter's 140 character limit.
+	 * @throws MessageTooLongException if the length of the status message exceeds Twitter's 280 character limit.
 	 * @throws OperationNotPermittedException if the photo resource isn't a GIF, JPG, or PNG.
 	 * @throws MissingAuthorizationException if TwitterTemplate was not created with OAuth credentials.
 	 */

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/TwitterErrorHandler.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/TwitterErrorHandler.java
@@ -145,8 +145,8 @@ class TwitterErrorHandler extends DefaultResponseErrorHandler {
 	}
 
 	private static final String INVALID_MESSAGE_RECIPIENT_TEXT = "You cannot send messages to users who are not following you.";
-	private static final String STATUS_TOO_LONG_TEXT = "Status is over 140 characters.";
-	private static final String MESSAGE_TOO_LONG_TEXT = "The text of your direct message is over 140 characters";
+	private static final String STATUS_TOO_LONG_TEXT = "Tweet needs to be a bit shorter.";
+	private static final String MESSAGE_TOO_LONG_TEXT = "The text of your direct message is over the max character limit.";
 	private static final String DUPLICATE_STATUS_TEXT = "Status is a duplicate.";
 	private static final String DAILY_RATE_LIMIT_TEXT = "User is over daily status update limit.";
 

--- a/spring-social-twitter/src/test/java/org/springframework/social/twitter/api/impl/DirectMessageTemplateTest.java
+++ b/spring-social-twitter/src/test/java/org/springframework/social/twitter/api/impl/DirectMessageTemplateTest.java
@@ -116,7 +116,8 @@ public class DirectMessageTemplateTest extends AbstractTwitterApiTest {
 	public void sendDirectMessage_toScreenName_tooLong() {
 		mockServer.expect(requestTo("https://api.twitter.com/1.1/direct_messages/new.json")).andExpect(method(POST))
 				.andExpect(content().string("screen_name=habuma&text=Really+long+message"))
-				.andRespond(withStatus(FORBIDDEN).body("{\"error\":\"There was an error sending your message: The text of your direct message is over 140 characters.\"}").contentType(APPLICATION_JSON));
+				.andRespond(withStatus(FORBIDDEN).body("{\"errors\":[{\"code\":354,\"message\":\"The text of your direct message is over the max character limit.\"}]}")
+                .contentType(APPLICATION_JSON));
 		twitter.directMessageOperations().sendDirectMessage("habuma", "Really long message");
 		mockServer.verify();
 	}

--- a/spring-social-twitter/src/test/java/org/springframework/social/twitter/api/impl/TimelineTemplateTest.java
+++ b/spring-social-twitter/src/test/java/org/springframework/social/twitter/api/impl/TimelineTemplateTest.java
@@ -450,7 +450,8 @@ public class TimelineTemplateTest extends AbstractTwitterApiTest {
 		mockServer.expect(requestTo("https://api.twitter.com/1.1/statuses/update.json"))
 			.andExpect(method(POST))
 			.andExpect(content().string("status=Really+long+message"))
-			.andRespond(withStatus(FORBIDDEN).body("{\"error\":\"Status is over 140 characters.\"}").contentType(APPLICATION_JSON));
+			.andRespond(withStatus(FORBIDDEN).body("{\"errors\":[{\"code\":186,\"message\":\"Tweet needs to be a bit shorter.\"}]}")
+            .contentType(APPLICATION_JSON));
 		twitter.timelineOperations().updateStatus("Really long message");
 	}
 	


### PR DESCRIPTION
Twitter changed there error texts therefore no MessageTooLongException are generated at the moment.