### PR TITLE
URL Cleanup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     repositories {
-        maven { url 'http://repo.spring.io/plugins-release' }
+        maven { url 'https://repo.spring.io/plugins-release' }
     }
     dependencies {
         classpath 'org.springframework.build.gradle:docbook-reference-plugin:0.2.8'
@@ -62,8 +62,8 @@ configure(allprojects - docProjects) {
     test.systemProperty("java.awt.headless", "true")
 
     repositories {
-        maven { url "http://repo.spring.io/libs-snapshot" }
-        maven { url "http://repo.spring.io/libs-milestone" }
+        maven { url "https://repo.spring.io/libs-snapshot" }
+        maven { url "https://repo.spring.io/libs-milestone" }
         mavenLocal()
     }
 
@@ -75,10 +75,10 @@ configure(allprojects - docProjects) {
     }
 
     ext.javadocLinks = [
-        "http://docs.oracle.com/javase/7/docs/api/",
-        "http://docs.oracle.com/javaee/7/api/",
-        "http://docs.spring.io/spring/docs/${springVersion}/javadoc-api/",
-        "http://docs.jboss.org/jbossas/javadoc/4.0.5/connector/"
+        "https://docs.oracle.com/javase/7/docs/api/",
+        "https://docs.oracle.com/javaee/7/api/",
+        "https://docs.spring.io/spring/docs/${springVersion}/javadoc-api/",
+        "https://docs.jboss.org/jbossas/javadoc/4.0.5/connector/"
     ] as String[]
 
     // servlet-api (2.5) and tomcat-servlet-api (3.0) classpath entries should not be

--- a/docs/docs.gradle
+++ b/docs/docs.gradle
@@ -62,9 +62,9 @@ task apidocs(type: Javadoc) {
 apidocs.options.outputLevel = org.gradle.external.javadoc.JavadocOutputLevel.QUIET
 
 apidocs.options.links = [
-    "http://static.springframework.org/spring/docs/3.2.x/javadoc-api",
-    "http://static.springsource.org/spring-ldap/docs/1.3.x/apidocs/",
-    "http://download.oracle.com/javase/6/docs/api/"
+    "https://docs.spring.io/spring/docs/3.2.x/javadoc-api",
+    "https://docs.spring.io/spring-ldap/docs/1.3.x/apidocs/",
+    "https://download.oracle.com/javase/6/docs/api/"
 ]
 
 apidocs.options.groups = [

--- a/publish-maven.gradle
+++ b/publish-maven.gradle
@@ -34,12 +34,12 @@ def customizePom(pom, gradleProject) {
             url = 'https://github.com/SpringSource/spring-social-twitter'
             organization {
                 name = 'SpringSource'
-                url = 'http://springsource.org/spring-social'
+                url = 'https://springsource.org/spring-social'
             }
             licenses {
                 license {
                     name 'The Apache Software License, Version 2.0'
-                    url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                    url 'https://www.apache.org/licenses/LICENSE-2.0.txt'
                     distribution 'repo'
                 }
             }

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://docs.jboss.org/jbossas/javadoc/4.0.5/connector/ with 1 occurrences migrated to:  
  https://docs.jboss.org/jbossas/javadoc/4.0.5/connector/ ([https](https://docs.jboss.org/jbossas/javadoc/4.0.5/connector/) result 200).
* http://docs.oracle.com/javaee/7/api/ with 1 occurrences migrated to:  
  https://docs.oracle.com/javaee/7/api/ ([https](https://docs.oracle.com/javaee/7/api/) result 200).
* http://docs.oracle.com/javase/7/docs/api/ with 1 occurrences migrated to:  
  https://docs.oracle.com/javase/7/docs/api/ ([https](https://docs.oracle.com/javase/7/docs/api/) result 200).
* http://static.springsource.org/spring-ldap/docs/1.3.x/apidocs/ (301) with 1 occurrences migrated to:  
  https://docs.spring.io/spring-ldap/docs/1.3.x/apidocs/ ([https](https://static.springsource.org/spring-ldap/docs/1.3.x/apidocs/) result 200).
* http://docs.spring.io/spring/docs/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring/docs/ ([https](https://docs.spring.io/spring/docs/) result 200).
* http://www.apache.org/licenses/LICENSE-2.0 with 1 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).
* http://www.apache.org/licenses/LICENSE-2.0.txt with 1 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0.txt ([https](https://www.apache.org/licenses/LICENSE-2.0.txt) result 200).
* http://static.springframework.org/spring/docs/3.2.x/javadoc-api (301) with 1 occurrences migrated to:  
  https://docs.spring.io/spring/docs/3.2.x/javadoc-api ([https](https://static.springframework.org/spring/docs/3.2.x/javadoc-api) result 301).
* http://springsource.org/spring-social with 1 occurrences migrated to:  
  https://springsource.org/spring-social ([https](https://springsource.org/spring-social) result 301).
* http://download.oracle.com/javase/6/docs/api/ with 1 occurrences migrated to:  
  https://download.oracle.com/javase/6/docs/api/ ([https](https://download.oracle.com/javase/6/docs/api/) result 302).
* http://repo.spring.io/libs-milestone with 1 occurrences migrated to:  
  https://repo.spring.io/libs-milestone ([https](https://repo.spring.io/libs-milestone) result 302).
* http://repo.spring.io/libs-snapshot with 1 occurrences migrated to:  
  https://repo.spring.io/libs-snapshot ([https](https://repo.spring.io/libs-snapshot) result 302).
* http://repo.spring.io/plugins-release with 1 occurrences migrated to:  
  https://repo.spring.io/plugins-release ([https](https://repo.spring.io/plugins-release) result 302).