### PR TITLE
URL Cleanup

### DIFF
--- a/src/reference/docbook/api.xml
+++ b/src/reference/docbook/api.xml
@@ -33,7 +33,7 @@ Twitter twitter = new TwitterTemplate();]]>
 	</para>
 	
 	<para>
-		If you are using Spring Social's <ulink url="http://docs.spring.io/spring-social/docs/1.0.x/reference/html/serviceprovider.html">service provider framework</ulink>, you can get an instance of <interfacename>Twitter</interfacename> from a <interfacename>Connection</interfacename>. 
+		If you are using Spring Social's <ulink url="https://docs.spring.io/spring-social/docs/1.0.x/reference/html/serviceprovider.html">service provider framework</ulink>, you can get an instance of <interfacename>Twitter</interfacename> from a <interfacename>Connection</interfacename>. 
 		For example, the following snippet calls <methodname>getApi()</methodname> on a connection to retrieve a <interfacename>Twitter</interfacename>:
 	</para>				
 	

--- a/src/reference/docbook/connecting.xml
+++ b/src/reference/docbook/connecting.xml
@@ -66,7 +66,7 @@ public class SocialConfig {
 	</para>	
 		
 	<para>
-		Refer to <ulink url="http://docs.spring.io/spring-social/docs/1.0.x/reference/html/connecting.html">Spring Social's reference documentation</ulink> for complete details on configuring <classname>ConnectController</classname> and its dependencies.
+		Refer to <ulink url="https://docs.spring.io/spring-social/docs/1.0.x/reference/html/connecting.html">Spring Social's reference documentation</ulink> for complete details on configuring <classname>ConnectController</classname> and its dependencies.
 	</para>
 			
 </chapter>

--- a/src/reference/docbook/index.xml
+++ b/src/reference/docbook/index.xml
@@ -5,8 +5,8 @@
   xmlns:xl="http://www.w3.org/1999/xlink"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="
-      http://docbook.org/ns/docbook http://www.docbook.org/xml/5.0/xsd/docbook.xsd 
-      http://www.w3.org/1999/xlink http://www.docbook.org/xml/5.0/xsd/xlink.xsd">
+      http://docbook.org/ns/docbook https://www.docbook.org/xml/5.0/xsd/docbook.xsd 
+      http://www.w3.org/1999/xlink https://www.docbook.org/xml/5.0/xsd/xlink.xsd">
 
   <info>
     <title>Spring Social Twitter Reference Manual</title>

--- a/src/reference/docbook/overview.xml
+++ b/src/reference/docbook/overview.xml
@@ -7,11 +7,11 @@
     <title>Introduction</title>
     
     <para>
-	    The Spring Social Twitter project is an extension to <ulink url="http://www.springframework.org/spring-social">Spring Social</ulink> that enables integration with Twitter.
+	    The Spring Social Twitter project is an extension to <ulink url="https://www.springframework.org/spring-social">Spring Social</ulink> that enables integration with Twitter.
 	</para>
 
 	<para>
-		<ulink url="http://www.twitter.com">Twitter</ulink> is a popular micro-blogging and social networking service, enabling people to communicate with each other 140 characters at a time.
+		<ulink url="https://www.twitter.com">Twitter</ulink> is a popular micro-blogging and social networking service, enabling people to communicate with each other 140 characters at a time.
 	</para>
 
 	<para>
@@ -54,7 +54,7 @@
 	</para>
 	
 	<para>
-		Consult <ulink url="http://docs.spring.io/spring-social/docs/1.0.x/reference/html/overview.html#overview-howtoget">Spring Social's reference documentation</ulink> for more information on Spring Social dependencies.
+		Consult <ulink url="https://docs.spring.io/spring-social/docs/1.0.x/reference/html/overview.html#overview-howtoget">Spring Social's reference documentation</ulink> for more information on Spring Social dependencies.
 	</para>
   </section>
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://www.springframework.org/spring-social (404) with 1 occurrences migrated to:  
  https://www.springframework.org/spring-social ([https](https://www.springframework.org/spring-social) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://docs.spring.io/spring-social/docs/1.0.x/reference/html/connecting.html with 1 occurrences migrated to:  
  https://docs.spring.io/spring-social/docs/1.0.x/reference/html/connecting.html ([https](https://docs.spring.io/spring-social/docs/1.0.x/reference/html/connecting.html) result 200).
* http://docs.spring.io/spring-social/docs/1.0.x/reference/html/overview.html with 1 occurrences migrated to:  
  https://docs.spring.io/spring-social/docs/1.0.x/reference/html/overview.html ([https](https://docs.spring.io/spring-social/docs/1.0.x/reference/html/overview.html) result 200).
* http://docs.spring.io/spring-social/docs/1.0.x/reference/html/serviceprovider.html with 1 occurrences migrated to:  
  https://docs.spring.io/spring-social/docs/1.0.x/reference/html/serviceprovider.html ([https](https://docs.spring.io/spring-social/docs/1.0.x/reference/html/serviceprovider.html) result 200).
* http://www.docbook.org/xml/5.0/xsd/docbook.xsd with 1 occurrences migrated to:  
  https://www.docbook.org/xml/5.0/xsd/docbook.xsd ([https](https://www.docbook.org/xml/5.0/xsd/docbook.xsd) result 301).
* http://www.docbook.org/xml/5.0/xsd/xlink.xsd with 1 occurrences migrated to:  
  https://www.docbook.org/xml/5.0/xsd/xlink.xsd ([https](https://www.docbook.org/xml/5.0/xsd/xlink.xsd) result 301).
* http://www.twitter.com with 1 occurrences migrated to:  
  https://www.twitter.com ([https](https://www.twitter.com) result 301).

# Ignored
These URLs were intentionally ignored.

* http://docbook.org/ns/docbook with 5 occurrences
* http://www.w3.org/1999/xlink with 5 occurrences
* http://www.w3.org/2001/XInclude with 1 occurrences
* http://www.w3.org/2001/XMLSchema-instance with 1 occurrences