### PR TITLE
URL Cleanup

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter-autoconfigure/src/main/java/org/springframework/social/twitter/autoconfigure/TwitterAutoConfiguration.java
+++ b/spring-social-twitter-autoconfigure/src/main/java/org/springframework/social/twitter/autoconfigure/TwitterAutoConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter-autoconfigure/src/main/java/org/springframework/social/twitter/autoconfigure/TwitterProperties.java
+++ b/spring-social-twitter-autoconfigure/src/main/java/org/springframework/social/twitter/autoconfigure/TwitterProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter-autoconfigure/src/main/java/org/springframework/social/twitter/autoconfigure/package-info.java
+++ b/spring-social-twitter-autoconfigure/src/main/java/org/springframework/social/twitter/autoconfigure/package-info.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter-autoconfigure/src/test/java/org/springframework/social/twitter/autoconfigure/AbstractSocialAutoConfigurationTests.java
+++ b/spring-social-twitter-autoconfigure/src/test/java/org/springframework/social/twitter/autoconfigure/AbstractSocialAutoConfigurationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter-autoconfigure/src/test/java/org/springframework/social/twitter/autoconfigure/TwitterAutoConfigurationTests.java
+++ b/spring-social-twitter-autoconfigure/src/test/java/org/springframework/social/twitter/autoconfigure/TwitterAutoConfigurationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/AbstractStreamParameters.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/AbstractStreamParameters.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/AccountSettings.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/AccountSettings.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/BlockOperations.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/BlockOperations.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/CursoredList.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/CursoredList.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/DirectMessage.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/DirectMessage.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/DirectMessageOperations.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/DirectMessageOperations.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/Entities.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/Entities.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/FilterStreamParameters.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/FilterStreamParameters.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/FriendOperations.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/FriendOperations.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/GeoCode.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/GeoCode.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/GeoOperations.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/GeoOperations.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/HashTagEntity.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/HashTagEntity.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/ImageSize.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/ImageSize.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/InvalidMessageRecipientException.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/InvalidMessageRecipientException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/ListOperations.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/ListOperations.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/MediaEntity.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/MediaEntity.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/MentionEntity.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/MentionEntity.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/MessageTooLongException.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/MessageTooLongException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/OEmbedOptions.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/OEmbedOptions.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/OEmbedTweet.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/OEmbedTweet.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/Place.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/Place.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/PlacePrototype.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/PlacePrototype.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/PlaceType.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/PlaceType.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/RateLimitStatus.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/RateLimitStatus.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/ResourceFamily.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/ResourceFamily.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/SavedSearch.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/SavedSearch.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/SearchOperations.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/SearchOperations.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/SearchParameters.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/SearchParameters.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/SearchResults.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/SearchResults.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/SimilarPlaces.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/SimilarPlaces.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/Stream.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/Stream.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/StreamDeleteEvent.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/StreamDeleteEvent.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/StreamListener.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/StreamListener.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/StreamWarningEvent.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/StreamWarningEvent.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/StreamingException.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/StreamingException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/StreamingOperations.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/StreamingOperations.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/SuggestionCategory.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/SuggestionCategory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/TickerSymbolEntity.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/TickerSymbolEntity.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/TimelineOperations.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/TimelineOperations.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/Trend.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/Trend.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/Trends.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/Trends.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/Tweet.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/Tweet.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/TweetData.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/TweetData.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/Twitter.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/Twitter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/TwitterObject.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/TwitterObject.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/TwitterProfile.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/TwitterProfile.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *	  http://www.apache.org/licenses/LICENSE-2.0
+ *	  https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/UrlEntity.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/UrlEntity.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *	  http://www.apache.org/licenses/LICENSE-2.0
+ *	  https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/UserList.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/UserList.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/UserOperations.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/UserOperations.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/UserStreamParameters.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/UserStreamParameters.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/AbstractTrendsList.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/AbstractTrendsList.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/AbstractTwitterOperations.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/AbstractTwitterOperations.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/AccountSettingsData.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/AccountSettingsData.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/ArrayUtils.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/ArrayUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/BlockTemplate.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/BlockTemplate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/ClientAuthorizedTwitterTemplate.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/ClientAuthorizedTwitterTemplate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/CursorUtils.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/CursorUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/CursoredLongList.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/CursoredLongList.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/CursoredTwitterProfileList.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/CursoredTwitterProfileList.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/DailyTrendsList.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/DailyTrendsList.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/DirectMessageList.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/DirectMessageList.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/DirectMessageMixin.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/DirectMessageMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/DirectMessageTemplate.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/DirectMessageTemplate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/EntitiesMixin.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/EntitiesMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/FriendTemplate.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/FriendTemplate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/GeoTemplate.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/GeoTemplate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/HashTagEntityMixin.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/HashTagEntityMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/ListTemplate.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/ListTemplate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/LocalTrendsDeserializer.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/LocalTrendsDeserializer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/LocalTrendsHolder.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/LocalTrendsHolder.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/MediaEntityMixin.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/MediaEntityMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/MentionEntityMixin.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/MentionEntityMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/OEmbedTweetMixin.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/OEmbedTweetMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/PagingUtils.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/PagingUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/PlaceMixin.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/PlaceMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/PlaceTypeDeserializer.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/PlaceTypeDeserializer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/PlacesList.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/PlacesList.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/RateLimitStatusDeserializer.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/RateLimitStatusDeserializer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/RateLimitStatusHolder.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/RateLimitStatusHolder.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/SavedSearchList.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/SavedSearchList.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/SavedSearchMixin.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/SavedSearchMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/SearchParametersUtil.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/SearchParametersUtil.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/SearchResultsMixin.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/SearchResultsMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/SearchTemplate.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/SearchTemplate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/SimilarPlacesDeserializer.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/SimilarPlacesDeserializer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/SimilarPlacesMixin.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/SimilarPlacesMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/SimilarPlacesResponse.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/SimilarPlacesResponse.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/StreamCreationException.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/StreamCreationException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/StreamDeleteEventMixin.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/StreamDeleteEventMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/StreamDispatcher.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/StreamDispatcher.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/StreamReader.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/StreamReader.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/StreamReaderImpl.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/StreamReaderImpl.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/StreamWarningEventMixin.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/StreamWarningEventMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/StreamingTemplate.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/StreamingTemplate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/SuggestionCategoryList.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/SuggestionCategoryList.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/SuggestionCategoryMixin.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/SuggestionCategoryMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/ThreadedStreamConsumer.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/ThreadedStreamConsumer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/TimelineDateDeserializer.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/TimelineDateDeserializer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/TimelineTemplate.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/TimelineTemplate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/TrackLimitEvent.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/TrackLimitEvent.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/TrendMixin.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/TrendMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/TrendsMixin.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/TrendsMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/TweetDeserializer.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/TweetDeserializer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/TweetMixin.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/TweetMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/TwitterErrorHandler.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/TwitterErrorHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/TwitterEscapingFormHttpMessageConverter.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/TwitterEscapingFormHttpMessageConverter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/TwitterModule.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/TwitterModule.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/TwitterProfileList.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/TwitterProfileList.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/TwitterProfileMixin.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/TwitterProfileMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/TwitterProfileUsersList.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/TwitterProfileUsersList.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/TwitterTemplate.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/TwitterTemplate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/UrlEntityMixin.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/UrlEntityMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *	  http://www.apache.org/licenses/LICENSE-2.0
+ *	  https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/UserListList.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/UserListList.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/UserListMixin.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/UserListMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/UserTemplate.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/UserTemplate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/WeeklyTrendsList.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/api/impl/WeeklyTrendsList.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/config/support/TwitterApiHelper.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/config/support/TwitterApiHelper.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/config/xml/TwitterConfigBeanDefinitionParser.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/config/xml/TwitterConfigBeanDefinitionParser.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/config/xml/TwitterNamespaceHandler.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/config/xml/TwitterNamespaceHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/connect/TwitterAdapter.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/connect/TwitterAdapter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/connect/TwitterConnectionFactory.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/connect/TwitterConnectionFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/main/java/org/springframework/social/twitter/connect/TwitterServiceProvider.java
+++ b/spring-social-twitter/src/main/java/org/springframework/social/twitter/connect/TwitterServiceProvider.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/test/java/org/springframework/social/twitter/api/impl/AbstractTwitterApiTest.java
+++ b/spring-social-twitter/src/test/java/org/springframework/social/twitter/api/impl/AbstractTwitterApiTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/test/java/org/springframework/social/twitter/api/impl/ApiErrorTest.java
+++ b/spring-social-twitter/src/test/java/org/springframework/social/twitter/api/impl/ApiErrorTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/test/java/org/springframework/social/twitter/api/impl/BlockTemplateTest.java
+++ b/spring-social-twitter/src/test/java/org/springframework/social/twitter/api/impl/BlockTemplateTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/test/java/org/springframework/social/twitter/api/impl/DirectMessageTemplateTest.java
+++ b/spring-social-twitter/src/test/java/org/springframework/social/twitter/api/impl/DirectMessageTemplateTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/test/java/org/springframework/social/twitter/api/impl/FriendTemplateTest.java
+++ b/spring-social-twitter/src/test/java/org/springframework/social/twitter/api/impl/FriendTemplateTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/test/java/org/springframework/social/twitter/api/impl/GeoTemplateTest.java
+++ b/spring-social-twitter/src/test/java/org/springframework/social/twitter/api/impl/GeoTemplateTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/test/java/org/springframework/social/twitter/api/impl/ListsTemplateTest.java
+++ b/spring-social-twitter/src/test/java/org/springframework/social/twitter/api/impl/ListsTemplateTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/test/java/org/springframework/social/twitter/api/impl/MockStream.java
+++ b/spring-social-twitter/src/test/java/org/springframework/social/twitter/api/impl/MockStream.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/test/java/org/springframework/social/twitter/api/impl/SearchParametersTest.java
+++ b/spring-social-twitter/src/test/java/org/springframework/social/twitter/api/impl/SearchParametersTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/test/java/org/springframework/social/twitter/api/impl/SearchTemplateTest.java
+++ b/spring-social-twitter/src/test/java/org/springframework/social/twitter/api/impl/SearchTemplateTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/test/java/org/springframework/social/twitter/api/impl/StreamConsumerTest.java
+++ b/spring-social-twitter/src/test/java/org/springframework/social/twitter/api/impl/StreamConsumerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/test/java/org/springframework/social/twitter/api/impl/StreamDispatcherTest.java
+++ b/spring-social-twitter/src/test/java/org/springframework/social/twitter/api/impl/StreamDispatcherTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/test/java/org/springframework/social/twitter/api/impl/StreamImplTest.java
+++ b/spring-social-twitter/src/test/java/org/springframework/social/twitter/api/impl/StreamImplTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/test/java/org/springframework/social/twitter/api/impl/StreamingTemplateTest.java
+++ b/spring-social-twitter/src/test/java/org/springframework/social/twitter/api/impl/StreamingTemplateTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/test/java/org/springframework/social/twitter/api/impl/TimelineTemplateTest.java
+++ b/spring-social-twitter/src/test/java/org/springframework/social/twitter/api/impl/TimelineTemplateTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/test/java/org/springframework/social/twitter/api/impl/TwitterTemplateTest.java
+++ b/spring-social-twitter/src/test/java/org/springframework/social/twitter/api/impl/TwitterTemplateTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/test/java/org/springframework/social/twitter/api/impl/UserTemplateTest.java
+++ b/spring-social-twitter/src/test/java/org/springframework/social/twitter/api/impl/UserTemplateTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-twitter/src/test/java/org/springframework/social/twitter/connect/TwitterAdapterTest.java
+++ b/spring-social-twitter/src/test/java/org/springframework/social/twitter/connect/TwitterAdapterTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/dist/license.txt
+++ b/src/dist/license.txt
@@ -1,6 +1,6 @@
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/reference/resources/xsl/html-custom.xsl
+++ b/src/reference/resources/xsl/html-custom.xsl
@@ -9,7 +9,7 @@
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+   https://www.apache.org/licenses/LICENSE-2.0
 
  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an

--- a/src/reference/resources/xsl/html-single-custom.xsl
+++ b/src/reference/resources/xsl/html-single-custom.xsl
@@ -9,7 +9,7 @@
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+   https://www.apache.org/licenses/LICENSE-2.0
 
  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an

--- a/src/reference/resources/xsl/pdf-custom.xsl
+++ b/src/reference/resources/xsl/pdf-custom.xsl
@@ -9,7 +9,7 @@
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+   https://www.apache.org/licenses/LICENSE-2.0
 
  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.apache.org/licenses/ with 2 occurrences migrated to:  
  https://www.apache.org/licenses/ ([https](https://www.apache.org/licenses/) result 200).
* [ ] http://www.apache.org/licenses/LICENSE-2.0 with 150 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).