### PR TITLE
URL Cleanup

### DIFF
--- a/src/reference/docbook/api.xml
+++ b/src/reference/docbook/api.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<chapter xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="apis" xmlns:xlink="http://www.w3.org/1999/xlink">
+<chapter xmlns="https://docbook.org/ns/docbook" version="5.0" xml:id="apis" xmlns:xlink="https://www.w3.org/1999/xlink">
 	<title>Twitter API Binding</title>
   
 	<para>
@@ -33,7 +33,7 @@ Twitter twitter = new TwitterTemplate();]]>
 	</para>
 	
 	<para>
-		If you are using Spring Social's <ulink url="http://docs.spring.io/spring-social/docs/1.0.x/reference/html/serviceprovider.html">service provider framework</ulink>, you can get an instance of <interfacename>Twitter</interfacename> from a <interfacename>Connection</interfacename>. 
+		If you are using Spring Social's <ulink url="https://docs.spring.io/spring-social/docs/1.0.x/reference/html/serviceprovider.html">service provider framework</ulink>, you can get an instance of <interfacename>Twitter</interfacename> from a <interfacename>Connection</interfacename>. 
 		For example, the following snippet calls <methodname>getApi()</methodname> on a connection to retrieve a <interfacename>Twitter</interfacename>:
 	</para>				
 	

--- a/src/reference/docbook/connecting.xml
+++ b/src/reference/docbook/connecting.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<chapter xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="connecting"
-		xmlns:xlink="http://www.w3.org/1999/xlink">
+<chapter xmlns="https://docbook.org/ns/docbook" version="5.0" xml:id="connecting"
+		xmlns:xlink="https://www.w3.org/1999/xlink">
 	<title>Configuring Twitter Connectivity</title>		
 
 	<para>
@@ -66,7 +66,7 @@ public class SocialConfig {
 	</para>	
 		
 	<para>
-		Refer to <ulink url="http://docs.spring.io/spring-social/docs/1.0.x/reference/html/connecting.html">Spring Social's reference documentation</ulink> for complete details on configuring <classname>ConnectController</classname> and its dependencies.
+		Refer to <ulink url="https://docs.spring.io/spring-social/docs/1.0.x/reference/html/connecting.html">Spring Social's reference documentation</ulink> for complete details on configuring <classname>ConnectController</classname> and its dependencies.
 	</para>
 			
 </chapter>

--- a/src/reference/docbook/index.xml
+++ b/src/reference/docbook/index.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <book xml:id="spring-framework-reference"
-  xmlns="http://docbook.org/ns/docbook" version="5.0"
-  xmlns:xi="http://www.w3.org/2001/XInclude"
-  xmlns:xl="http://www.w3.org/1999/xlink"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="https://docbook.org/ns/docbook" version="5.0"
+  xmlns:xi="https://www.w3.org/2001/XInclude"
+  xmlns:xl="https://www.w3.org/1999/xlink"
+  xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="
-      http://docbook.org/ns/docbook http://www.docbook.org/xml/5.0/xsd/docbook.xsd 
-      http://www.w3.org/1999/xlink http://www.docbook.org/xml/5.0/xsd/xlink.xsd">
+      https://docbook.org/ns/docbook https://www.docbook.org/xml/5.0/xsd/docbook.xsd 
+      https://www.w3.org/1999/xlink https://www.docbook.org/xml/5.0/xsd/xlink.xsd">
 
   <info>
     <title>Spring Social Twitter Reference Manual</title>

--- a/src/reference/docbook/overview.xml
+++ b/src/reference/docbook/overview.xml
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<chapter xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="overview"
-    xmlns:xlink="http://www.w3.org/1999/xlink">
+<chapter xmlns="https://docbook.org/ns/docbook" version="5.0" xml:id="overview"
+    xmlns:xlink="https://www.w3.org/1999/xlink">
   <title>Spring Social Twitter Overview</title>
 
   <section id="overview-introduction">
     <title>Introduction</title>
     
     <para>
-	    The Spring Social Twitter project is an extension to <ulink url="http://www.springframework.org/spring-social">Spring Social</ulink> that enables integration with Twitter.
+	    The Spring Social Twitter project is an extension to <ulink url="https://www.springframework.org/spring-social">Spring Social</ulink> that enables integration with Twitter.
 	</para>
 
 	<para>
-		<ulink url="http://www.twitter.com">Twitter</ulink> is a popular micro-blogging and social networking service, enabling people to communicate with each other 140 characters at a time.
+		<ulink url="https://www.twitter.com">Twitter</ulink> is a popular micro-blogging and social networking service, enabling people to communicate with each other 140 characters at a time.
 	</para>
 
 	<para>
@@ -54,7 +54,7 @@
 	</para>
 	
 	<para>
-		Consult <ulink url="http://docs.spring.io/spring-social/docs/1.0.x/reference/html/overview.html#overview-howtoget">Spring Social's reference documentation</ulink> for more information on Spring Social dependencies.
+		Consult <ulink url="https://docs.spring.io/spring-social/docs/1.0.x/reference/html/overview.html#overview-howtoget">Spring Social's reference documentation</ulink> for more information on Spring Social dependencies.
 	</para>
   </section>
 

--- a/src/reference/resources/images/callouts/1.svg
+++ b/src/reference/resources/images/callouts/1.svg
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 12.0.1, SVG Export Plug-In . SVG Version: 6.00 Build 51448)  -->
 <!DOCTYPE svg [
-	<!ENTITY ns_svg "http://www.w3.org/2000/svg">
-	<!ENTITY ns_xlink "http://www.w3.org/1999/xlink">
+	<!ENTITY ns_svg "https://www.w3.org/2000/svg">
+	<!ENTITY ns_xlink "https://www.w3.org/1999/xlink">
 ]>
 <svg  version="1.0" id="Layer_1" xmlns="&ns_svg;" xmlns:xlink="&ns_xlink;" width="33" height="33" viewBox="0 0 33 33"
 	 style="overflow:visible;enable-background:new 0 0 33 33;" xml:space="preserve">

--- a/src/reference/resources/images/callouts/10.svg
+++ b/src/reference/resources/images/callouts/10.svg
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 12.0.1, SVG Export Plug-In . SVG Version: 6.00 Build 51448)  -->
 <!DOCTYPE svg [
-	<!ENTITY ns_svg "http://www.w3.org/2000/svg">
-	<!ENTITY ns_xlink "http://www.w3.org/1999/xlink">
+	<!ENTITY ns_svg "https://www.w3.org/2000/svg">
+	<!ENTITY ns_xlink "https://www.w3.org/1999/xlink">
 ]>
 <svg  version="1.0" id="Layer_1" xmlns="&ns_svg;" xmlns:xlink="&ns_xlink;" width="33" height="33" viewBox="0 0 33 33"
 	 style="overflow:visible;enable-background:new 0 0 33 33;" xml:space="preserve">

--- a/src/reference/resources/images/callouts/11.svg
+++ b/src/reference/resources/images/callouts/11.svg
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 12.0.1, SVG Export Plug-In . SVG Version: 6.00 Build 51448)  -->
 <!DOCTYPE svg [
-	<!ENTITY ns_svg "http://www.w3.org/2000/svg">
-	<!ENTITY ns_xlink "http://www.w3.org/1999/xlink">
+	<!ENTITY ns_svg "https://www.w3.org/2000/svg">
+	<!ENTITY ns_xlink "https://www.w3.org/1999/xlink">
 ]>
 <svg  version="1.0" id="Layer_1" xmlns="&ns_svg;" xmlns:xlink="&ns_xlink;" width="33" height="33" viewBox="0 0 33 33"
 	 style="overflow:visible;enable-background:new 0 0 33 33;" xml:space="preserve">

--- a/src/reference/resources/images/callouts/12.svg
+++ b/src/reference/resources/images/callouts/12.svg
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 12.0.1, SVG Export Plug-In . SVG Version: 6.00 Build 51448)  -->
 <!DOCTYPE svg [
-	<!ENTITY ns_svg "http://www.w3.org/2000/svg">
-	<!ENTITY ns_xlink "http://www.w3.org/1999/xlink">
+	<!ENTITY ns_svg "https://www.w3.org/2000/svg">
+	<!ENTITY ns_xlink "https://www.w3.org/1999/xlink">
 ]>
 <svg  version="1.0" id="Layer_1" xmlns="&ns_svg;" xmlns:xlink="&ns_xlink;" width="33" height="33" viewBox="0 0 33 33"
 	 style="overflow:visible;enable-background:new 0 0 33 33;" xml:space="preserve">

--- a/src/reference/resources/images/callouts/13.svg
+++ b/src/reference/resources/images/callouts/13.svg
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 12.0.1, SVG Export Plug-In . SVG Version: 6.00 Build 51448)  -->
 <!DOCTYPE svg [
-	<!ENTITY ns_svg "http://www.w3.org/2000/svg">
-	<!ENTITY ns_xlink "http://www.w3.org/1999/xlink">
+	<!ENTITY ns_svg "https://www.w3.org/2000/svg">
+	<!ENTITY ns_xlink "https://www.w3.org/1999/xlink">
 ]>
 <svg  version="1.0" id="Layer_1" xmlns="&ns_svg;" xmlns:xlink="&ns_xlink;" width="33" height="33" viewBox="0 0 33 33"
 	 style="overflow:visible;enable-background:new 0 0 33 33;" xml:space="preserve">

--- a/src/reference/resources/images/callouts/14.svg
+++ b/src/reference/resources/images/callouts/14.svg
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 12.0.1, SVG Export Plug-In . SVG Version: 6.00 Build 51448)  -->
 <!DOCTYPE svg [
-	<!ENTITY ns_svg "http://www.w3.org/2000/svg">
-	<!ENTITY ns_xlink "http://www.w3.org/1999/xlink">
+	<!ENTITY ns_svg "https://www.w3.org/2000/svg">
+	<!ENTITY ns_xlink "https://www.w3.org/1999/xlink">
 ]>
 <svg  version="1.0" id="Layer_1" xmlns="&ns_svg;" xmlns:xlink="&ns_xlink;" width="33" height="33" viewBox="0 0 33 33"
 	 style="overflow:visible;enable-background:new 0 0 33 33;" xml:space="preserve">

--- a/src/reference/resources/images/callouts/15.svg
+++ b/src/reference/resources/images/callouts/15.svg
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 12.0.1, SVG Export Plug-In . SVG Version: 6.00 Build 51448)  -->
 <!DOCTYPE svg [
-	<!ENTITY ns_svg "http://www.w3.org/2000/svg">
-	<!ENTITY ns_xlink "http://www.w3.org/1999/xlink">
+	<!ENTITY ns_svg "https://www.w3.org/2000/svg">
+	<!ENTITY ns_xlink "https://www.w3.org/1999/xlink">
 ]>
 <svg  version="1.0" id="Layer_1" xmlns="&ns_svg;" xmlns:xlink="&ns_xlink;" width="33" height="33" viewBox="0 0 33 33"
 	 style="overflow:visible;enable-background:new 0 0 33 33;" xml:space="preserve">

--- a/src/reference/resources/images/callouts/16.svg
+++ b/src/reference/resources/images/callouts/16.svg
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 12.0.1, SVG Export Plug-In . SVG Version: 6.00 Build 51448)  -->
 <!DOCTYPE svg [
-	<!ENTITY ns_svg "http://www.w3.org/2000/svg">
-	<!ENTITY ns_xlink "http://www.w3.org/1999/xlink">
+	<!ENTITY ns_svg "https://www.w3.org/2000/svg">
+	<!ENTITY ns_xlink "https://www.w3.org/1999/xlink">
 ]>
 <svg  version="1.0" id="Layer_1" xmlns="&ns_svg;" xmlns:xlink="&ns_xlink;" width="33" height="33" viewBox="0 0 33 33"
 	 style="overflow:visible;enable-background:new 0 0 33 33;" xml:space="preserve">

--- a/src/reference/resources/images/callouts/17.svg
+++ b/src/reference/resources/images/callouts/17.svg
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 12.0.1, SVG Export Plug-In . SVG Version: 6.00 Build 51448)  -->
 <!DOCTYPE svg [
-	<!ENTITY ns_svg "http://www.w3.org/2000/svg">
-	<!ENTITY ns_xlink "http://www.w3.org/1999/xlink">
+	<!ENTITY ns_svg "https://www.w3.org/2000/svg">
+	<!ENTITY ns_xlink "https://www.w3.org/1999/xlink">
 ]>
 <svg  version="1.0" id="Layer_1" xmlns="&ns_svg;" xmlns:xlink="&ns_xlink;" width="33" height="33" viewBox="0 0 33 33"
 	 style="overflow:visible;enable-background:new 0 0 33 33;" xml:space="preserve">

--- a/src/reference/resources/images/callouts/18.svg
+++ b/src/reference/resources/images/callouts/18.svg
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 12.0.1, SVG Export Plug-In . SVG Version: 6.00 Build 51448)  -->
 <!DOCTYPE svg [
-	<!ENTITY ns_svg "http://www.w3.org/2000/svg">
-	<!ENTITY ns_xlink "http://www.w3.org/1999/xlink">
+	<!ENTITY ns_svg "https://www.w3.org/2000/svg">
+	<!ENTITY ns_xlink "https://www.w3.org/1999/xlink">
 ]>
 <svg  version="1.0" id="Layer_1" xmlns="&ns_svg;" xmlns:xlink="&ns_xlink;" width="33" height="33" viewBox="0 0 33 33"
 	 style="overflow:visible;enable-background:new 0 0 33 33;" xml:space="preserve">

--- a/src/reference/resources/images/callouts/19.svg
+++ b/src/reference/resources/images/callouts/19.svg
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 12.0.1, SVG Export Plug-In . SVG Version: 6.00 Build 51448)  -->
 <!DOCTYPE svg [
-	<!ENTITY ns_svg "http://www.w3.org/2000/svg">
-	<!ENTITY ns_xlink "http://www.w3.org/1999/xlink">
+	<!ENTITY ns_svg "https://www.w3.org/2000/svg">
+	<!ENTITY ns_xlink "https://www.w3.org/1999/xlink">
 ]>
 <svg  version="1.0" id="Layer_1" xmlns="&ns_svg;" xmlns:xlink="&ns_xlink;" width="33" height="33" viewBox="0 0 33 33"
 	 style="overflow:visible;enable-background:new 0 0 33 33;" xml:space="preserve">

--- a/src/reference/resources/images/callouts/2.svg
+++ b/src/reference/resources/images/callouts/2.svg
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 12.0.1, SVG Export Plug-In . SVG Version: 6.00 Build 51448)  -->
 <!DOCTYPE svg [
-	<!ENTITY ns_svg "http://www.w3.org/2000/svg">
-	<!ENTITY ns_xlink "http://www.w3.org/1999/xlink">
+	<!ENTITY ns_svg "https://www.w3.org/2000/svg">
+	<!ENTITY ns_xlink "https://www.w3.org/1999/xlink">
 ]>
 <svg  version="1.0" id="Layer_1" xmlns="&ns_svg;" xmlns:xlink="&ns_xlink;" width="33" height="33" viewBox="0 0 33 33"
 	 style="overflow:visible;enable-background:new 0 0 33 33;" xml:space="preserve">

--- a/src/reference/resources/images/callouts/20.svg
+++ b/src/reference/resources/images/callouts/20.svg
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 12.0.1, SVG Export Plug-In . SVG Version: 6.00 Build 51448)  -->
 <!DOCTYPE svg [
-	<!ENTITY ns_svg "http://www.w3.org/2000/svg">
-	<!ENTITY ns_xlink "http://www.w3.org/1999/xlink">
+	<!ENTITY ns_svg "https://www.w3.org/2000/svg">
+	<!ENTITY ns_xlink "https://www.w3.org/1999/xlink">
 ]>
 <svg  version="1.0" id="Layer_1" xmlns="&ns_svg;" xmlns:xlink="&ns_xlink;" width="33" height="33" viewBox="0 0 33 33"
 	 style="overflow:visible;enable-background:new 0 0 33 33;" xml:space="preserve">

--- a/src/reference/resources/images/callouts/21.svg
+++ b/src/reference/resources/images/callouts/21.svg
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 12.0.1, SVG Export Plug-In . SVG Version: 6.00 Build 51448)  -->
 <!DOCTYPE svg [
-	<!ENTITY ns_svg "http://www.w3.org/2000/svg">
-	<!ENTITY ns_xlink "http://www.w3.org/1999/xlink">
+	<!ENTITY ns_svg "https://www.w3.org/2000/svg">
+	<!ENTITY ns_xlink "https://www.w3.org/1999/xlink">
 ]>
 <svg  version="1.0" id="Layer_1" xmlns="&ns_svg;" xmlns:xlink="&ns_xlink;" width="33" height="33" viewBox="0 0 33 33"
 	 style="overflow:visible;enable-background:new 0 0 33 33;" xml:space="preserve">

--- a/src/reference/resources/images/callouts/22.svg
+++ b/src/reference/resources/images/callouts/22.svg
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 12.0.1, SVG Export Plug-In . SVG Version: 6.00 Build 51448)  -->
 <!DOCTYPE svg [
-	<!ENTITY ns_svg "http://www.w3.org/2000/svg">
-	<!ENTITY ns_xlink "http://www.w3.org/1999/xlink">
+	<!ENTITY ns_svg "https://www.w3.org/2000/svg">
+	<!ENTITY ns_xlink "https://www.w3.org/1999/xlink">
 ]>
 <svg  version="1.0" id="Layer_1" xmlns="&ns_svg;" xmlns:xlink="&ns_xlink;" width="33" height="33" viewBox="0 0 33 33"
 	 style="overflow:visible;enable-background:new 0 0 33 33;" xml:space="preserve">

--- a/src/reference/resources/images/callouts/23.svg
+++ b/src/reference/resources/images/callouts/23.svg
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 12.0.1, SVG Export Plug-In . SVG Version: 6.00 Build 51448)  -->
 <!DOCTYPE svg [
-	<!ENTITY ns_svg "http://www.w3.org/2000/svg">
-	<!ENTITY ns_xlink "http://www.w3.org/1999/xlink">
+	<!ENTITY ns_svg "https://www.w3.org/2000/svg">
+	<!ENTITY ns_xlink "https://www.w3.org/1999/xlink">
 ]>
 <svg  version="1.0" id="Layer_1" xmlns="&ns_svg;" xmlns:xlink="&ns_xlink;" width="33" height="33" viewBox="0 0 33 33"
 	 style="overflow:visible;enable-background:new 0 0 33 33;" xml:space="preserve">

--- a/src/reference/resources/images/callouts/24.svg
+++ b/src/reference/resources/images/callouts/24.svg
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 12.0.1, SVG Export Plug-In . SVG Version: 6.00 Build 51448)  -->
 <!DOCTYPE svg [
-	<!ENTITY ns_svg "http://www.w3.org/2000/svg">
-	<!ENTITY ns_xlink "http://www.w3.org/1999/xlink">
+	<!ENTITY ns_svg "https://www.w3.org/2000/svg">
+	<!ENTITY ns_xlink "https://www.w3.org/1999/xlink">
 ]>
 <svg  version="1.0" id="Layer_1" xmlns="&ns_svg;" xmlns:xlink="&ns_xlink;" width="33" height="33" viewBox="0 0 33 33"
 	 style="overflow:visible;enable-background:new 0 0 33 33;" xml:space="preserve">

--- a/src/reference/resources/images/callouts/25.svg
+++ b/src/reference/resources/images/callouts/25.svg
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 12.0.1, SVG Export Plug-In . SVG Version: 6.00 Build 51448)  -->
 <!DOCTYPE svg [
-	<!ENTITY ns_svg "http://www.w3.org/2000/svg">
-	<!ENTITY ns_xlink "http://www.w3.org/1999/xlink">
+	<!ENTITY ns_svg "https://www.w3.org/2000/svg">
+	<!ENTITY ns_xlink "https://www.w3.org/1999/xlink">
 ]>
 <svg  version="1.0" id="Layer_1" xmlns="&ns_svg;" xmlns:xlink="&ns_xlink;" width="33" height="33" viewBox="0 0 33 33"
 	 style="overflow:visible;enable-background:new 0 0 33 33;" xml:space="preserve">

--- a/src/reference/resources/images/callouts/26.svg
+++ b/src/reference/resources/images/callouts/26.svg
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 12.0.1, SVG Export Plug-In . SVG Version: 6.00 Build 51448)  -->
 <!DOCTYPE svg [
-	<!ENTITY ns_svg "http://www.w3.org/2000/svg">
-	<!ENTITY ns_xlink "http://www.w3.org/1999/xlink">
+	<!ENTITY ns_svg "https://www.w3.org/2000/svg">
+	<!ENTITY ns_xlink "https://www.w3.org/1999/xlink">
 ]>
 <svg  version="1.0" id="Layer_1" xmlns="&ns_svg;" xmlns:xlink="&ns_xlink;" width="33" height="33" viewBox="0 0 33 33"
 	 style="overflow:visible;enable-background:new 0 0 33 33;" xml:space="preserve">

--- a/src/reference/resources/images/callouts/27.svg
+++ b/src/reference/resources/images/callouts/27.svg
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 12.0.1, SVG Export Plug-In . SVG Version: 6.00 Build 51448)  -->
 <!DOCTYPE svg [
-	<!ENTITY ns_svg "http://www.w3.org/2000/svg">
-	<!ENTITY ns_xlink "http://www.w3.org/1999/xlink">
+	<!ENTITY ns_svg "https://www.w3.org/2000/svg">
+	<!ENTITY ns_xlink "https://www.w3.org/1999/xlink">
 ]>
 <svg  version="1.0" id="Layer_1" xmlns="&ns_svg;" xmlns:xlink="&ns_xlink;" width="33" height="33" viewBox="0 0 33 33"
 	 style="overflow:visible;enable-background:new 0 0 33 33;" xml:space="preserve">

--- a/src/reference/resources/images/callouts/28.svg
+++ b/src/reference/resources/images/callouts/28.svg
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 12.0.1, SVG Export Plug-In . SVG Version: 6.00 Build 51448)  -->
 <!DOCTYPE svg [
-	<!ENTITY ns_svg "http://www.w3.org/2000/svg">
-	<!ENTITY ns_xlink "http://www.w3.org/1999/xlink">
+	<!ENTITY ns_svg "https://www.w3.org/2000/svg">
+	<!ENTITY ns_xlink "https://www.w3.org/1999/xlink">
 ]>
 <svg  version="1.0" id="Layer_1" xmlns="&ns_svg;" xmlns:xlink="&ns_xlink;" width="33" height="33" viewBox="0 0 33 33"
 	 style="overflow:visible;enable-background:new 0 0 33 33;" xml:space="preserve">

--- a/src/reference/resources/images/callouts/29.svg
+++ b/src/reference/resources/images/callouts/29.svg
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 12.0.1, SVG Export Plug-In . SVG Version: 6.00 Build 51448)  -->
 <!DOCTYPE svg [
-	<!ENTITY ns_svg "http://www.w3.org/2000/svg">
-	<!ENTITY ns_xlink "http://www.w3.org/1999/xlink">
+	<!ENTITY ns_svg "https://www.w3.org/2000/svg">
+	<!ENTITY ns_xlink "https://www.w3.org/1999/xlink">
 ]>
 <svg  version="1.0" id="Layer_1" xmlns="&ns_svg;" xmlns:xlink="&ns_xlink;" width="33" height="33" viewBox="0 0 33 33"
 	 style="overflow:visible;enable-background:new 0 0 33 33;" xml:space="preserve">

--- a/src/reference/resources/images/callouts/3.svg
+++ b/src/reference/resources/images/callouts/3.svg
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 12.0.1, SVG Export Plug-In . SVG Version: 6.00 Build 51448)  -->
 <!DOCTYPE svg [
-	<!ENTITY ns_svg "http://www.w3.org/2000/svg">
-	<!ENTITY ns_xlink "http://www.w3.org/1999/xlink">
+	<!ENTITY ns_svg "https://www.w3.org/2000/svg">
+	<!ENTITY ns_xlink "https://www.w3.org/1999/xlink">
 ]>
 <svg  version="1.0" id="Layer_1" xmlns="&ns_svg;" xmlns:xlink="&ns_xlink;" width="33" height="33" viewBox="0 0 33 33"
 	 style="overflow:visible;enable-background:new 0 0 33 33;" xml:space="preserve">

--- a/src/reference/resources/images/callouts/30.svg
+++ b/src/reference/resources/images/callouts/30.svg
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 12.0.1, SVG Export Plug-In . SVG Version: 6.00 Build 51448)  -->
 <!DOCTYPE svg [
-	<!ENTITY ns_svg "http://www.w3.org/2000/svg">
-	<!ENTITY ns_xlink "http://www.w3.org/1999/xlink">
+	<!ENTITY ns_svg "https://www.w3.org/2000/svg">
+	<!ENTITY ns_xlink "https://www.w3.org/1999/xlink">
 ]>
 <svg  version="1.0" id="Layer_1" xmlns="&ns_svg;" xmlns:xlink="&ns_xlink;" width="33" height="33" viewBox="0 0 33 33"
 	 style="overflow:visible;enable-background:new 0 0 33 33;" xml:space="preserve">

--- a/src/reference/resources/images/callouts/4.svg
+++ b/src/reference/resources/images/callouts/4.svg
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 12.0.1, SVG Export Plug-In . SVG Version: 6.00 Build 51448)  -->
 <!DOCTYPE svg [
-	<!ENTITY ns_svg "http://www.w3.org/2000/svg">
-	<!ENTITY ns_xlink "http://www.w3.org/1999/xlink">
+	<!ENTITY ns_svg "https://www.w3.org/2000/svg">
+	<!ENTITY ns_xlink "https://www.w3.org/1999/xlink">
 ]>
 <svg  version="1.0" id="Layer_1" xmlns="&ns_svg;" xmlns:xlink="&ns_xlink;" width="33" height="33" viewBox="0 0 33 33"
 	 style="overflow:visible;enable-background:new 0 0 33 33;" xml:space="preserve">

--- a/src/reference/resources/images/callouts/5.svg
+++ b/src/reference/resources/images/callouts/5.svg
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 12.0.1, SVG Export Plug-In . SVG Version: 6.00 Build 51448)  -->
 <!DOCTYPE svg [
-	<!ENTITY ns_svg "http://www.w3.org/2000/svg">
-	<!ENTITY ns_xlink "http://www.w3.org/1999/xlink">
+	<!ENTITY ns_svg "https://www.w3.org/2000/svg">
+	<!ENTITY ns_xlink "https://www.w3.org/1999/xlink">
 ]>
 <svg  version="1.0" id="Layer_1" xmlns="&ns_svg;" xmlns:xlink="&ns_xlink;" width="33" height="33" viewBox="0 0 33 33"
 	 style="overflow:visible;enable-background:new 0 0 33 33;" xml:space="preserve">

--- a/src/reference/resources/images/callouts/6.svg
+++ b/src/reference/resources/images/callouts/6.svg
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 12.0.1, SVG Export Plug-In . SVG Version: 6.00 Build 51448)  -->
 <!DOCTYPE svg [
-	<!ENTITY ns_svg "http://www.w3.org/2000/svg">
-	<!ENTITY ns_xlink "http://www.w3.org/1999/xlink">
+	<!ENTITY ns_svg "https://www.w3.org/2000/svg">
+	<!ENTITY ns_xlink "https://www.w3.org/1999/xlink">
 ]>
 <svg  version="1.0" id="Layer_1" xmlns="&ns_svg;" xmlns:xlink="&ns_xlink;" width="33" height="33" viewBox="0 0 33 33"
 	 style="overflow:visible;enable-background:new 0 0 33 33;" xml:space="preserve">

--- a/src/reference/resources/images/callouts/7.svg
+++ b/src/reference/resources/images/callouts/7.svg
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 12.0.1, SVG Export Plug-In . SVG Version: 6.00 Build 51448)  -->
 <!DOCTYPE svg [
-	<!ENTITY ns_svg "http://www.w3.org/2000/svg">
-	<!ENTITY ns_xlink "http://www.w3.org/1999/xlink">
+	<!ENTITY ns_svg "https://www.w3.org/2000/svg">
+	<!ENTITY ns_xlink "https://www.w3.org/1999/xlink">
 ]>
 <svg  version="1.0" id="Layer_1" xmlns="&ns_svg;" xmlns:xlink="&ns_xlink;" width="33" height="33" viewBox="0 0 33 33"
 	 style="overflow:visible;enable-background:new 0 0 33 33;" xml:space="preserve">

--- a/src/reference/resources/images/callouts/8.svg
+++ b/src/reference/resources/images/callouts/8.svg
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 12.0.1, SVG Export Plug-In . SVG Version: 6.00 Build 51448)  -->
 <!DOCTYPE svg [
-	<!ENTITY ns_svg "http://www.w3.org/2000/svg">
-	<!ENTITY ns_xlink "http://www.w3.org/1999/xlink">
+	<!ENTITY ns_svg "https://www.w3.org/2000/svg">
+	<!ENTITY ns_xlink "https://www.w3.org/1999/xlink">
 ]>
 <svg  version="1.0" id="Layer_1" xmlns="&ns_svg;" xmlns:xlink="&ns_xlink;" width="33" height="33" viewBox="0 0 33 33"
 	 style="overflow:visible;enable-background:new 0 0 33 33;" xml:space="preserve">

--- a/src/reference/resources/images/callouts/9.svg
+++ b/src/reference/resources/images/callouts/9.svg
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 12.0.1, SVG Export Plug-In . SVG Version: 6.00 Build 51448)  -->
 <!DOCTYPE svg [
-	<!ENTITY ns_svg "http://www.w3.org/2000/svg">
-	<!ENTITY ns_xlink "http://www.w3.org/1999/xlink">
+	<!ENTITY ns_svg "https://www.w3.org/2000/svg">
+	<!ENTITY ns_xlink "https://www.w3.org/1999/xlink">
 ]>
 <svg  version="1.0" id="Layer_1" xmlns="&ns_svg;" xmlns:xlink="&ns_xlink;" width="33" height="33" viewBox="0 0 33 33"
 	 style="overflow:visible;enable-background:new 0 0 33 33;" xml:space="preserve">


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://www.springframework.org/spring-social (404) with 1 occurrences migrated to:  
  https://www.springframework.org/spring-social ([https](https://www.springframework.org/spring-social) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://docbook.org/ns/docbook with 5 occurrences migrated to:  
  https://docbook.org/ns/docbook ([https](https://docbook.org/ns/docbook) result 200).
* [ ] http://docs.spring.io/spring-social/docs/1.0.x/reference/html/connecting.html with 1 occurrences migrated to:  
  https://docs.spring.io/spring-social/docs/1.0.x/reference/html/connecting.html ([https](https://docs.spring.io/spring-social/docs/1.0.x/reference/html/connecting.html) result 200).
* [ ] http://docs.spring.io/spring-social/docs/1.0.x/reference/html/overview.html with 1 occurrences migrated to:  
  https://docs.spring.io/spring-social/docs/1.0.x/reference/html/overview.html ([https](https://docs.spring.io/spring-social/docs/1.0.x/reference/html/overview.html) result 200).
* [ ] http://docs.spring.io/spring-social/docs/1.0.x/reference/html/serviceprovider.html with 1 occurrences migrated to:  
  https://docs.spring.io/spring-social/docs/1.0.x/reference/html/serviceprovider.html ([https](https://docs.spring.io/spring-social/docs/1.0.x/reference/html/serviceprovider.html) result 200).
* [ ] http://www.w3.org/1999/xlink with 35 occurrences migrated to:  
  https://www.w3.org/1999/xlink ([https](https://www.w3.org/1999/xlink) result 200).
* [ ] http://www.w3.org/2000/svg with 30 occurrences migrated to:  
  https://www.w3.org/2000/svg ([https](https://www.w3.org/2000/svg) result 200).
* [ ] http://www.w3.org/2001/XMLSchema-instance with 1 occurrences migrated to:  
  https://www.w3.org/2001/XMLSchema-instance ([https](https://www.w3.org/2001/XMLSchema-instance) result 200).
* [ ] http://www.docbook.org/xml/5.0/xsd/docbook.xsd with 1 occurrences migrated to:  
  https://www.docbook.org/xml/5.0/xsd/docbook.xsd ([https](https://www.docbook.org/xml/5.0/xsd/docbook.xsd) result 301).
* [ ] http://www.docbook.org/xml/5.0/xsd/xlink.xsd with 1 occurrences migrated to:  
  https://www.docbook.org/xml/5.0/xsd/xlink.xsd ([https](https://www.docbook.org/xml/5.0/xsd/xlink.xsd) result 301).
* [ ] http://www.twitter.com with 1 occurrences migrated to:  
  https://www.twitter.com ([https](https://www.twitter.com) result 301).
* [ ] http://www.w3.org/2001/XInclude with 1 occurrences migrated to:  
  https://www.w3.org/2001/XInclude ([https](https://www.w3.org/2001/XInclude) result 301).